### PR TITLE
MessageBus: introduce MessagePool for static allocation

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -62,7 +62,7 @@ pub const journal_headers_max = switch (deployment_environment) {
     else => 16384,
 };
 
-/// The maximum size of a request or response in bytes:
+/// The maximum size of a message in bytes:
 /// This is also the limit of all inflight data across multiple pipelined requests per connection.
 /// We may have one request of up to 4 MiB inflight or 4 pipelined requests of up to 1 MiB inflight.
 /// This impacts sequential disk write throughput, the larger the buffer the better.
@@ -70,9 +70,8 @@ pub const journal_headers_max = switch (deployment_environment) {
 /// However, this impacts bufferbloat and head-of-line blocking latency for pipelined requests.
 /// For a 1 Gbps NIC = 125 MiB/s throughput: 4 MiB / 125 * 1000ms = 32ms for the next request.
 /// This also impacts the amount of memory allocated at initialization by the server.
-/// e.g. connections_max * (request_size_max + response_size_max) = 32 * (4 + 4) = 256 MiB
-pub const request_size_max = 4 * 1024 * 1024;
-pub const response_size_max = 4 * 1024 * 1024;
+/// e.g. connections_max * message_size_max = 32 * (4 + 4) = 256 MiB
+pub const message_size_max = 4 * 1024 * 1024;
 
 /// The maximum number of connections that can be accepted and held open by the server at any time:
 pub const connections_max = 32;

--- a/src/journal.zig
+++ b/src/journal.zig
@@ -282,7 +282,7 @@ pub const Journal = struct {
         assert(@mod(config.journal_size_max, buffer.len) == 0);
         assert(buffer.len > @sizeOf(JournalHeader));
 
-        var state_output = try self.allocator.alloc(u8, config.response_size_max);
+        const state_output = try self.allocator.alloc(u8, config.message_size_max);
         defer self.allocator.free(state_output);
 
         // Read entry headers from the head of the journal:

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -1,0 +1,121 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const mem = std.mem;
+
+const config = @import("config.zig");
+
+comptime {
+    // message_size_max must be a multiple of sector_size for Direct I/O
+    assert(config.message_size_max % config.sector_size == 0);
+}
+
+const vr = @import("vr.zig");
+const Header = vr.Header;
+
+/// A pool of config.connections_max messages of config.message_size_max as well as a further
+/// config.connections_max header-sized messages for use in sending.
+pub const MessagePool = struct {
+    pub const Message = struct {
+        header: *Header,
+        /// Unless this Message is header only, this buffer is in aligned to config.sector_size
+        /// and casting to that alignment in order to perform Direct I/O is safe.
+        buffer: []u8,
+        references: u32 = 0,
+        next: ?*Message,
+
+        /// Increment the reference count of the message and return the same pointer passed.
+        pub fn ref(message: *Message) *Message {
+            message.references += 1;
+            return message;
+        }
+
+        fn header_only(message: Message) bool {
+            const ret = message.buffer.len == @sizeOf(Header);
+            assert(ret or message.buffer.len == config.message_size_max);
+            return ret;
+        }
+    };
+
+    /// List of currently unused messages of config.message_size_max
+    free_list: ?*Message,
+    /// List of currently usused header-sized messages
+    header_only_free_list: ?*Message,
+
+    pub fn init(allocator: *mem.Allocator) error{OutOfMemory}!MessagePool {
+        var ret: MessagePool = .{
+            .free_list = null,
+            .header_only_free_list = null,
+        };
+
+        var i: usize = 0;
+        while (i < config.connections_max) : (i += 1) {
+            {
+                const buffer = try allocator.allocAdvanced(
+                    u8,
+                    config.sector_size,
+                    config.message_size_max,
+                    .exact,
+                );
+                mem.set(u8, buffer, 0);
+                const message = try allocator.create(Message);
+                message.* = .{
+                    .header = mem.bytesAsValue(Header, buffer[0..@sizeOf(Header)]),
+                    .buffer = buffer,
+                    .next = ret.free_list,
+                };
+                ret.free_list = message;
+            }
+            {
+                const header = try allocator.create(Header);
+                const message = try allocator.create(Message);
+                message.* = .{
+                    .header = header,
+                    .buffer = mem.asBytes(header),
+                    .next = ret.header_only_free_list,
+                };
+                ret.header_only_free_list = message;
+            }
+        }
+
+        return ret;
+    }
+
+    /// Get an unused message with a buffer of config.message_size_max. If no such message is
+    /// available, an error is returned. The returned message has exactly one reference.
+    pub fn get_message(pool: *MessagePool) ?*Message {
+        const ret = pool.free_list orelse return null;
+        pool.free_list = ret.next;
+        ret.next = null;
+        assert(!ret.header_only());
+        assert(ret.references == 0);
+        ret.references = 1;
+        return ret;
+    }
+
+    /// Get an unused message with a buffer only large enough to hold a header. If no such message
+    /// is available, an error is returned. The returned message has exactly one reference.
+    pub fn get_header_only_message(pool: *MessagePool) ?*Message {
+        const ret = pool.header_only_free_list orelse return null;
+        pool.header_only_free_list = ret.next;
+        ret.next = null;
+        assert(ret.header_only());
+        assert(ret.references == 0);
+        ret.references = 1;
+        return ret;
+    }
+
+    /// Decrement the reference count of the message, possibly freeing it.
+    pub fn unref(pool: *MessagePool, message: *Message) void {
+        message.references -= 1;
+        if (message.references == 0) {
+            mem.set(u8, message.buffer, 0);
+            if (message.header_only()) {
+                message.next = pool.header_only_free_list;
+                pool.header_only_free_list = message;
+            } else {
+                message.next = pool.free_list;
+                pool.free_list = message;
+            }
+        }
+    }
+};

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -71,7 +71,7 @@ pub fn run() !void {
 
         if (leader) |replica| {
             if (ticks == 1 or ticks == 5) {
-                var request = message_bus.create_message(config.sector_size) catch unreachable;
+                const request = message_bus.get_message() orelse unreachable;
                 defer message_bus.unref(request);
 
                 request.header.* = .{


### PR DESCRIPTION
Messages and their buffers are now allocated once at start up and reused throughout the lifetime of the program.

The exact numbers used for pool size can of course be tweaked in the future as we see what is actually needed in practice.

To keep the commit smaller and easier to review, the improvement to reduce the number of recv calls used has not yet been made, it will be a little more invasive than expected and I'd rather do that in a follow up commit.

I'm mostly looking for confirmation that my new error handling logic in `vr.zig` is correct.