### PR TITLE
MessageBus: reduce number of recv operations

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -62,6 +62,9 @@ pub const journal_headers_max = switch (deployment_environment) {
     else => 16384,
 };
 
+/// The maximum number of connections that can be accepted and held open by the server at any time:
+pub const connections_max = 32;
+
 /// The maximum size of a message in bytes:
 /// This is also the limit of all inflight data across multiple pipelined requests per connection.
 /// We may have one request of up to 4 MiB inflight or 4 pipelined requests of up to 1 MiB inflight.
@@ -70,11 +73,13 @@ pub const journal_headers_max = switch (deployment_environment) {
 /// However, this impacts bufferbloat and head-of-line blocking latency for pipelined requests.
 /// For a 1 Gbps NIC = 125 MiB/s throughput: 4 MiB / 125 * 1000ms = 32ms for the next request.
 /// This also impacts the amount of memory allocated at initialization by the server.
-/// e.g. connections_max * message_size_max = 32 * (4 + 4) = 256 MiB
 pub const message_size_max = 4 * 1024 * 1024;
 
-/// The maximum number of connections that can be accepted and held open by the server at any time:
-pub const connections_max = 32;
+/// The number of full-sized messages allocated at initialization by the message bus.
+pub const message_bus_messages_max = connections_max * 2;
+/// The number of header-sized messages allocated at initialization by the message bus.
+/// These are much smaller/cheaper and we can therefore have many of them.
+pub const message_bus_headers_max = connections_max * connection_send_queue_max;
 
 /// The minimum and maximum amount of time in milliseconds to wait before initiating a connection.
 /// Exponential backoff and full jitter are applied within this range.

--- a/src/fifo.zig
+++ b/src/fifo.zig
@@ -26,11 +26,70 @@ pub fn FIFO(comptime T: type) type {
             const ret = self.out orelse return null;
             self.out = ret.next;
             ret.next = null;
+            if (self.in == ret) self.in = null;
             return ret;
         }
 
         pub fn peek(self: Self) ?*T {
             return self.out;
         }
+
+        /// Remove an element from the FIFO. Asserts that the element is
+        /// in the FIFO. This operation is O(N), if this is done often you
+        /// probably want a different data structure.
+        pub fn remove(self: *Self, to_remove: *T) void {
+            if (to_remove == self.out) {
+                _ = self.pop();
+                return;
+            }
+            var it = self.out;
+            while (it) |elem| : (it = elem.next) {
+                if (to_remove == elem.next) {
+                    elem.next = to_remove.next;
+                    to_remove.next = null;
+                    break;
+                }
+            } else unreachable;
+        }
     };
+}
+
+test "push/pop/peek/remove" {
+    const testing = @import("std").testing;
+
+    const Foo = struct { next: ?*@This() = null };
+
+    var one: Foo = .{};
+    var two: Foo = .{};
+    var three: Foo = .{};
+
+    var fifo: FIFO(Foo) = .{};
+
+    fifo.push(&one);
+    testing.expectEqual(@as(?*Foo, &one), fifo.peek());
+
+    fifo.push(&two);
+    fifo.push(&three);
+    testing.expectEqual(@as(?*Foo, &one), fifo.peek());
+
+    fifo.remove(&one);
+    testing.expectEqual(@as(?*Foo, &two), fifo.pop());
+    testing.expectEqual(@as(?*Foo, &three), fifo.pop());
+    testing.expectEqual(@as(?*Foo, null), fifo.pop());
+
+    fifo.push(&one);
+    fifo.push(&two);
+    fifo.push(&three);
+    fifo.remove(&two);
+    testing.expectEqual(@as(?*Foo, &one), fifo.pop());
+    testing.expectEqual(@as(?*Foo, &three), fifo.pop());
+    testing.expectEqual(@as(?*Foo, null), fifo.pop());
+
+    fifo.push(&one);
+    fifo.push(&two);
+    fifo.push(&three);
+    fifo.remove(&three);
+    testing.expectEqual(@as(?*Foo, &one), fifo.pop());
+    testing.expectEqual(@as(?*Foo, &two), fifo.pop());
+    testing.expectEqual(@as(?*Foo, null), fifo.pop());
 }

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -182,7 +182,8 @@ pub const MessageBus = struct {
             defer self.unref(message);
 
             // Now that we have a message, remove this connection from the FIFO:
-            _ = self.connections_waiting_for_a_message.pop().?;
+            const removed = self.connections_waiting_for_a_message.pop().?;
+            assert(removed == connection);
 
             if (connection.recv_message == null) {
                 // A null recv_message indicates that this Connection has

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -738,15 +738,16 @@ const Connection = struct {
             return null;
         }
 
+        // Ensure that the message is addressed to the correct cluster.
+        if (header.cluster != self.message_bus.server.cluster) {
+            log.err("received message addressed to wrong cluster: {}", .{header.cluster});
+            self.terminate(.shutdown);
+            return null;
+        }
+
         switch (self.peer) {
             .none => unreachable,
             .unknown => {
-                // Ensure that the message is addressed to the correct cluster.
-                if (header.cluster != self.message_bus.server.cluster) {
-                    log.err("received message addressed to wrong cluster: {}", .{header.cluster});
-                    self.terminate(.shutdown);
-                    return null;
-                }
                 // The only command sent by clients is the request command.
                 if (header.command == .request) {
                     self.peer = .{ .client = header.client };

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -840,7 +840,7 @@ const Connection = struct {
             on_recv,
             &self.recv_completion,
             self.fd,
-            self.recv_message.?.buffer[self.recv_progress..],
+            self.recv_message.?.buffer[self.recv_progress..config.message_size_max],
             os.MSG_NOSIGNAL,
         );
     }

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -808,7 +808,7 @@ const Connection = struct {
 
     /// Acquires a free message if necessary and then calls `recv()`.
     /// If the connection has a `recv_message` and the message being parsed is at pole position then
-    /// `recv()` immediately, otherwise copies any partial message into the new `recv_message`.
+    /// calls `recv()` immediately, otherwise copies any partial message into new `recv_message`.
     fn get_recv_message_and_recv(self: *Connection) void {
         if (self.recv_message != null and self.recv_parsed == 0) {
             self.recv();

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -4,16 +4,21 @@ const mem = std.mem;
 
 const config = @import("config.zig");
 
+const vr = @import("vr.zig");
+const Header = vr.Header;
+
 comptime {
     // message_size_max must be a multiple of sector_size for Direct I/O
     assert(config.message_size_max % config.sector_size == 0);
 }
 
-const vr = @import("vr.zig");
-const Header = vr.Header;
+/// Add an extra sector_size bytes to allow a partially received subsequent
+/// message to be shifted to make space for 0 padding to Journal.sector_ceil.
+const message_size_max_padded = config.message_size_max + config.sector_size;
 
-/// A pool of config.connections_max messages of config.message_size_max as well as a further
-/// config.connections_max header-sized messages for use in sending.
+/// A pool of reference-counted Messages, memory for which is allocated only once
+/// during initialization and reused thereafter. The config.message_bus_messages_max
+/// and config.message_bus_headers_max values determine the size of this pool.
 pub const MessagePool = struct {
     pub const Message = struct {
         header: *Header,
@@ -31,12 +36,12 @@ pub const MessagePool = struct {
 
         fn header_only(message: Message) bool {
             const ret = message.buffer.len == @sizeOf(Header);
-            assert(ret or message.buffer.len == config.message_size_max);
+            assert(ret or message.buffer.len == message_size_max_padded);
             return ret;
         }
     };
 
-    /// List of currently unused messages of config.message_size_max
+    /// List of currently unused messages of message_size_max_padded
     free_list: ?*Message,
     /// List of currently usused header-sized messages
     header_only_free_list: ?*Message,
@@ -46,14 +51,13 @@ pub const MessagePool = struct {
             .free_list = null,
             .header_only_free_list = null,
         };
-
-        var i: usize = 0;
-        while (i < config.connections_max) : (i += 1) {
-            {
+        {
+            var i: usize = 0;
+            while (i < config.message_bus_messages_max) : (i += 1) {
                 const buffer = try allocator.allocAdvanced(
                     u8,
                     config.sector_size,
-                    config.message_size_max,
+                    message_size_max_padded,
                     .exact,
                 );
                 mem.set(u8, buffer, 0);
@@ -65,7 +69,10 @@ pub const MessagePool = struct {
                 };
                 ret.free_list = message;
             }
-            {
+        }
+        {
+            var i: usize = 0;
+            while (i < config.message_bus_headers_max) : (i += 1) {
                 const header = try allocator.create(Header);
                 const message = try allocator.create(Message);
                 message.* = .{

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -60,7 +60,6 @@ pub const MessagePool = struct {
                     message_size_max_padded,
                     .exact,
                 );
-                mem.set(u8, buffer, 0);
                 const message = try allocator.create(Message);
                 message.* = .{
                     .header = mem.bytesAsValue(Header, buffer[0..@sizeOf(Header)]),
@@ -115,7 +114,7 @@ pub const MessagePool = struct {
     pub fn unref(pool: *MessagePool, message: *Message) void {
         message.references -= 1;
         if (message.references == 0) {
-            mem.set(u8, message.buffer, 0);
+            if (std.builtin.mode == .Debug) mem.set(u8, message.buffer, undefined);
             if (message.header_only()) {
                 message.next = pool.header_only_free_list;
                 pool.header_only_free_list = message;


### PR DESCRIPTION
Currently we do a minimum of 2 recv operations for every received
message: one to receive the header and one for the body.

In the interest of reducing the number of separate I/O operations needed
for better performance, rework the MessageBus to always pass the
full-sized recv buffer to the kernel and deal with any possible
partially received messages added to the buffer gracefully. This makes
it possible to receive many messages with a single recv operation if
there are many queued up in kernel buffers.