### PR TITLE
client: refactor `request`

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -21,7 +21,7 @@ const CommitTransfersResult = tb.CommitTransfersResult;
 
 const log = std.log;
 
-pub const ClientError = packed enum(u32) {
+pub const ClientError = error{
     BatchNotQueued,
 };
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -22,7 +22,7 @@ const CommitTransfersResult = tb.CommitTransfersResult;
 const log = std.log;
 
 pub const ClientError = error{
-    BatchNotQueued,
+    TooManyOutstandingRequests,
 };
 
 pub const Client = struct {
@@ -155,11 +155,14 @@ pub const Client = struct {
             .operation = operation,
             .message = message.ref(),
         }) catch |err| switch (err) {
-            .NoSpaceLeft => callback(
-                user_data,
-                operation,
-                error.BatchNotQueued,
-            ),
+            error.NoSpaceLeft => {
+                callback(
+                    user_data,
+                    operation,
+                    error.TooManyOutstandingRequests,
+                );
+                return;
+            },
             else => unreachable,
         };
 


### PR DESCRIPTION
This update lets the user ask the client to get an available message from the message_bus and makes
it possible for calling code to copy straight into the message buffer. The `request` function then
takes in the message that is to be sent and prepares the header.