### PR TITLE
Marzullo's algorithm

### DIFF
--- a/src/clock.zig
+++ b/src/clock.zig
@@ -1,201 +1,327 @@
 const std = @import("std");
 const assert = std.debug.assert;
+const log = std.log.scoped(.clock);
+
+const config = @import("config.zig");
+
+const clock_offset_tolerance: u64 = config.clock_offset_tolerance_max_ms * std.time.ns_per_ms;
+const epoch_max: u64 = config.clock_epoch_max_ms * std.time.ns_per_ms;
+const window_min: u64 = config.clock_synchronization_window_min_ms * std.time.ns_per_ms;
+const window_max: u64 = config.clock_synchronization_window_max_ms * std.time.ns_per_ms;
 
 const Marzullo = @import("marzullo.zig").Marzullo;
 
 const Sample = struct {
+    /// The relative difference between our wall clock reading and that of the remote clock source.
     clock_offset: i64,
     one_way_delay: u64,
 };
 
-pub const Clock = struct {
-    allocator: *std.mem.Allocator,
-    replica: u8,
+const Epoch = struct {
+    const Self = @This();
+
+    /// The best clock offset sample per remote clock source (with minimum one way delay) collected
+    /// over the course of a window period of several seconds.
     sources: []?Sample,
-    clock_offset_max: u64,
-    window_duration_min: u64,
-    window_duration_max: u64,
-    window_epoch_monotonic: u64,
-    window_epoch_realtime: i64,
+
+    /// The monotonic clock timestamp when this epoch began. We use this to measure elapsed time.
+    monotonic: u64,
+
+    /// The wall clock timestamp when this epoch began. We add the elapsed monotonic time to this
+    /// plus the synchronized clock offset to arrive at a synchronized realtime timestamp. We
+    /// capture this realtime when starting the epoch, before we take any samples, to guard against
+    /// any jumps in the system's realtime clock from impacting our measurements.
+    realtime: i64,
+
+    /// Once we have enough source clock offset samples in agreement, the epoch is synchronized.
+    /// We then have lower and upper bounds on the true cluster time, and can install this epoch for
+    /// subsequent clock readings. This epoch is then valid for several seconds, while clock drift
+    /// has not had enough time to accumulate into any significant clock skew, and while we collect
+    /// samples for the next epoch to refresh and replace this one.
+    synchronized: ?Marzullo.Interval,
+
+    /// A guard to prevent synchronizing too often without having learned any new samples.
+    learned: bool = false,
+
+    fn elapsed(self: *Self, clock: *Clock) u64 {
+        return clock.monotonic() - self.monotonic;
+    }
+
+    fn reset(self: *Self, clock: *Clock) void {
+        std.mem.set(?Sample, self.sources, null);
+        // A replica always has zero clock offset and network delay to its own system time reading:
+        self.sources[clock.replica] = Sample{
+            .clock_offset = 0,
+            .one_way_delay = 0,
+        };
+        self.monotonic = clock.monotonic();
+        self.realtime = clock.realtime();
+        self.synchronized = null;
+        self.learned = false;
+    }
+};
+
+pub const Clock = struct {
+    const Self = @This();
+
+    allocator: *std.mem.Allocator,
+
+    /// The index of the replica using this clock to provide synchronized time.
+    replica: u8,
+
+    /// The underlying time source for this clock (system time or deterministic time).
+    /// TODO Replace this with SystemTime in production, or DeterministicTime in testing.
+    time: *DeterministicTime,
+
+    /// An epoch from which the clock can read synchronized clock timestamps within safe bounds.
+    /// At least `config.clock_synchronization_window_min_ms` is needed for this to be ready to use.
+    epoch: Epoch,
+
+    /// The next epoch (collecting samples and being synchronized) to replace the current epoch.
+    window: Epoch,
+
+    /// A static allocation to convert window samples into tuple bounds for Marzullo's algorithm.
     marzullo_tuples: []Marzullo.Tuple,
-    epoch_monotonic: ?u64 = null,
-    epoch_realtime: ?i64 = null,
-    epoch_clock_offset: ?i64 = null,
 
     pub fn init(
         allocator: *std.mem.Allocator,
+        /// The size of the cluster, i.e. the number of clock sources (including this replica).
         replica_count: u8,
         replica: u8,
+        time: *DeterministicTime,
     ) !Clock {
         assert(replica_count > 0);
         assert(replica < replica_count);
 
-        var sources = try allocator.alloc(?Sample, replica_count);
-        errdefer allocator.free(sources);
+        var epoch: Epoch = undefined;
+        epoch.sources = try allocator.alloc(?Sample, replica_count);
+        errdefer allocator.free(epoch.sources);
+
+        var window: Epoch = undefined;
+        window.sources = try allocator.alloc(?Sample, replica_count);
+        errdefer allocator.free(window.sources);
 
         // There are two Marzullo tuple bounds (lower and upper) per source clock offset sample:
-        var marzullo_tuples = try allocator.alloc(Marzullo.Tuple, sources.len * 2);
+        var marzullo_tuples = try allocator.alloc(Marzullo.Tuple, replica_count * 2);
         errdefer allocator.free(marzullo_tuples);
 
         var self = Clock{
             .allocator = allocator,
             .replica = replica,
-            .sources = sources,
-            .clock_offset_max = 10 * std.time.ns_per_s,
-            .window_duration_min = 2 * std.time.ns_per_s,
-            .window_duration_max = 8 * std.time.ns_per_s,
-            .window_epoch_monotonic = undefined,
-            .window_epoch_realtime = undefined,
+            .time = time,
+            .epoch = epoch,
+            .window = window,
             .marzullo_tuples = marzullo_tuples,
         };
-        self.open_new_window();
+
+        // Reset the current epoch to be unsynchronized,
+        self.epoch.reset(&self);
+        // and open a new epoch window to start collecting samples...
+        self.window.reset(&self);
+
         return self;
     }
 
     /// Called by `Replica.on_pong()` with:
-    /// * the index of the `replica` we pinged that has now ponged back,
-    /// * our monotonic timestamp `m0` embedded in the ping we sent, copied over to the pong reply,
+    /// * the index of the `replica` that has replied to our ping with a pong,
+    /// * our monotonic timestamp `m0` embedded in the ping we sent, carried over into this pong,
     /// * the remote replica's `realtime()` timestamp `t1`, and
-    /// * our monotonic timestamp `m2` as captured by the `Replica.on_pong()` handler.
-    pub fn learn_from_roundtrip(self: *Clock, replica: u8, m0: u64, t1: i64, m2: u64) void {
-        assert(replica != self.replica);
+    /// * our monotonic timestamp `m2` as captured by our `Replica.on_pong()` handler.
+    pub fn learn(self: *Self, replica: u8, m0: u64, t1: i64, m2: u64) void {
+        // A network routing fault must have replayed one of our outbound messages back against us:
+        if (replica == self.replica) return;
 
+        // Our m0 and m2 readings should always be monotonically increasing.
+        // This condition should never be true. Reject this as a bad sample:
         if (m0 >= m2) return;
-        // TODO We may receive delayed packets after a reboot, in which case m0/m2 will be invalid.
-        // We should add a 128-bit identifier to ping/pongs to bind them to the current window.
-        if (m0 < self.window_epoch_monotonic) return;
-        if (m2 < self.window_epoch_monotonic) return;
-        const window_elapsed: u64 = m2 - self.window_epoch_monotonic;
-        if (window_elapsed > self.window_duration_max) return;
+
+        // We may receive delayed packets after a reboot, in which case m0/m2 will also be invalid:
+        // TODO Add an identifier for this epoch to pings/pongs to bind them to the current window.
+        if (m0 < self.window.monotonic) return;
+        if (m2 < self.window.monotonic) return;
+        const elapsed: u64 = m2 - self.window.monotonic;
+        if (elapsed > window_max) return;
 
         const round_trip_time: u64 = m2 - m0;
         const one_way_delay: u64 = round_trip_time / 2;
-        const t2: i64 = self.window_epoch_realtime + @intCast(i64, window_elapsed);
+        const t2: i64 = self.window.realtime + @intCast(i64, elapsed);
         const clock_offset: i64 = t1 + @intCast(i64, one_way_delay) - t2;
 
-        // TODO Correct asymmetric error when we can see it's there.
-        // "A System for Clock Synchronization in an Internet of Things"
+        log.debug("learn: replica={} m0={} t1={} m2={} t2={} one_way_delay={} clock_offset={}", .{
+            replica,
+            m0,
+            t1,
+            m2,
+            t2,
+            one_way_delay,
+            clock_offset,
+        });
 
-        self.sources[replica] = choose_minimum_one_way_delay(self.sources[replica], Sample{
+        // TODO Correct asymmetric error when we can see it's there.
+        // "A System for Clock Synchronization in an Internet of Things" Section 4.2
+
+        // The less network delay, the more likely we have an accurante clock offset measurement:
+        self.window.sources[replica] = minimum_one_way_delay(self.window.sources[replica], Sample{
             .clock_offset = clock_offset,
             .one_way_delay = one_way_delay,
         });
 
-        self.close_window();
+        // We decouple calls to `synchronize()` so that it's not triggered by these network events.
+        // Otherwise, excessive duplicate network packets would burn the CPU.
+        self.window.learned = true;
     }
 
-    /// Called by `Replica.on_ping_timeout()` to provide `m0` when a replica decides to send a ping.
-    /// Called by `Replica.on_pong()` to provide `m2` when the replica receives the pong.
-    pub fn monotonic(self: *Clock) u64 {
-        return monotonic_timestamp();
+    /// Called by `Replica.on_ping_timeout()` to provide `m0` when we decide to send a ping.
+    /// Called by `Replica.on_pong()` to provide `m2` when we receive a pong.
+    pub fn monotonic(self: *Self) u64 {
+        return self.time.monotonic();
     }
 
     /// Called by `Replica.on_ping()` when responding to a ping with a pong.
     /// We use synchronized time if possible, so that the cluster remembers true time as a whole.
-    /// We fall back to our wall clock if we do not have synchronized time.
-    pub fn realtime(self: *Clock) i64 {
-        if (self.synchronized()) |realtime| {
-            return realtime;
-        } else {
-            return realtime_timestamp();
-        }
+    /// Otherwise, if one or two replicas with accurate clocks fail we may be unable to synchronize.
+    /// We fall back to offering our wall clock reading if we do not yet have any synchronized time.
+    /// This should never be used by the state machine, only for measuring clock offsets.
+    pub fn realtime(self: *Self) i64 {
+        return self.realtime_synchronized() orelse self.time.realtime();
     }
 
     /// Called by `StateMachine.prepare_timestamp()` when the leader wants to timestamp a batch.
-    /// If the leader's clock is not synchronized with the cluster, it will wait until it is.
-    pub fn realtime_synchronized(self: *Clock) ?i64 {
-        if (self.epoch_clock_offset) |clock_offset| {
-            // TODO We can alternatively compare our estimated time with NTP and prefer NTP
-            // provided it is within our synchronized bounds.
-            // This means that installations with more accurate time sources will use those, and we
-            // have guardrails and defense in depth if those time sources fail.
-            const epoch_elapsed = monotonic_timestamp() - self.epoch_monotonic.?;
-            return self.epoch_realtime.? + clock_offset + @intCast(i64, epoch_elapsed);
+    /// If the leader's clock is not synchronized with the cluster, it must wait until it is.
+    /// Returns the system time clamped to be within our synchronized lower and upper bounds.
+    /// This is complementary to NTP and allows clusters with very accurate time to make use of it,
+    /// while providing guard rails for when NTP is partitioned or unable to correct quickly enough.
+    pub fn realtime_synchronized(self: *Self) ?i64 {
+        if (self.epoch.synchronized) |interval| {
+            const elapsed = @intCast(i64, self.epoch.elapsed(self));
+            return std.math.clamp(
+                self.time.realtime(),
+                self.epoch.realtime + elapsed + interval.lower_bound,
+                self.epoch.realtime + elapsed + interval.upper_bound,
+            );
         } else {
             return null;
         }
     }
 
-    pub fn tick(self: *Clock) void {
-        self.close_window();
+    pub fn tick(self: *Self) void {
+        self.time.tick();
+        self.synchronize();
+
+        // Expire the current epoch if successive windows failed to synchronize:
+        // Gradual clock drift prevents us from using an epoch for more than a few tens of seconds.
+        if (self.epoch.synchronized != null and self.epoch.elapsed(self) >= epoch_max) {
+            log.alert("no agreement on cluster time (partitioned or too many clock faults)", .{});
+            self.epoch.reset(self);
+        }
     }
 
-    /// Round trip delay is the biggest component of estimation error, so we choose the smallest.
-    fn choose_minimum_one_way_delay(a: ?Sample, b: ?Sample) ?Sample {
-        if (a == null) return b;
-        if (b == null) return a;
-        if (a.?.one_way_delay < b.?.one_way_delay) return a;
-        // Choose B if B's one way delay is less or the same (we assume B is the newer sample):
-        return b;
-    }
+    fn synchronize(self: *Self) void {
+        assert(self.window.synchronized == null);
 
-    fn close_window(self: *Clock) void {
-        const window_elapsed = monotonic_timestamp() - self.window_epoch_monotonic;
-        if (window_elapsed < self.window_duration_min) return;
-        if (window_elapsed >= self.window_duration_max) {
-            // TODO Warn that our window expired.
-            self.open_new_window();
+        // Avoid polling the monotonic time if we know we have no new samples to synchronize on:
+        if (!self.window.learned) return;
+
+        // Wait until the window has enough accurate samples:
+        const elapsed = self.window.elapsed(self);
+        if (elapsed < window_min) return;
+        if (elapsed >= window_max) {
+            // We took too long to synchronize the window, expire stale samples...
+            log.crit("expiring synchronization window after {}", .{std.fmt.fmtDuration(elapsed)});
+            self.window.reset(self);
             return;
         }
 
-        if (self.synchronize_window()) |interval| {
-            assert(interval.sources_true > @divTrunc(self.sources.len, 2));
-
-            self.epoch_monotonic = self.window_epoch_monotonic;
-            self.epoch_realtime = self.window_epoch_realtime;
-            self.epoch_clock_offset = interval.lower_bound;
-
-            // TODO Add debug logs.
-            self.open_new_window();
-        }
-    }
-
-    fn open_new_window(self: *Clock) void {
-        std.mem.set(?Sample, self.sources, null);
-        self.sources[self.replica] = Sample{
-            .clock_offset = 0,
-            .one_way_delay = 0,
-        };
-        self.window_epoch_monotonic = monotonic_timestamp();
-        self.window_epoch_realtime = realtime_timestamp();
-        std.mem.set(Marzullo.Tuple, self.marzullo_tuples, undefined);
-    }
-
-    fn synchronize_window(self: *Clock) ?Marzullo.Interval {
-        const window_elapsed = monotonic_timestamp() - self.window_epoch_monotonic;
-        if (window_elapsed < self.window_duration_min) return null;
-
         // Starting with the most clock offset tolerance, while we have a majority, find the best
         // smallest interval with the least clock offset tolerance, reducing tolerance at each step:
-        var best: ?Marzullo.Interval = null;
+        var tolerance: u64 = clock_offset_tolerance;
+        var terminate = false;
+        var rounds: usize = 0;
+        // Do at least one round if tolerance=0 and cap the number of rounds to avoid runaway loops.
+        while (!terminate and rounds < 64) : (tolerance /= 2) {
+            if (tolerance == 0) terminate = true;
+            rounds += 1;
 
-        var tolerance = self.clock_offset_max;
-        while (tolerance > 0) : (tolerance /= 16) {
             var interval = Marzullo.smallest_interval(self.window_tuples(tolerance));
-            const majority = interval.sources_true > @divTrunc(self.sources.len, 2);
+            const majority = interval.sources_true > @divTrunc(self.window.sources.len, 2);
             if (!majority) break;
-            best = interval;
+
+            // The new interval may reduce the number of `sources_true` while also decreasing error.
+            // In other words, provided we maintain a majority, we prefer tighter tolerance bounds.
+            self.window.synchronized = interval;
         }
 
-        return best;
+        // Do not reset `learned` any earlier than this (before we have attempted to synchronize).
+        self.window.learned = false;
+
+        // Wait for more accurate samples or until we timeout the window for lack of majority:
+        if (self.window.synchronized == null) return;
+
+        var old_epoch_synchronized = self.epoch.synchronized;
+
+        var new_window = self.epoch;
+        new_window.reset(self);
+        self.epoch = self.window;
+        self.window = new_window;
+
+        self.after_synchronization(old_epoch_synchronized);
     }
 
-    fn window_tuples(self: *Clock, clock_offset_max: u64) []Marzullo.Tuple {
-        assert(self.sources[self.replica].?.clock_offset == 0);
-        assert(self.sources[self.replica].?.one_way_delay == 0);
+    fn after_synchronization(self: *Self, old_epoch_synchronized: ?Marzullo.Interval) void {
+        const new_interval = self.epoch.synchronized.?;
+
+        log.info("synchronized: truechimers={}/{} clock_offset={}..{} accuracy={}", .{
+            new_interval.sources_true,
+            self.epoch.sources.len,
+            fmtDurationSigned(new_interval.lower_bound),
+            fmtDurationSigned(new_interval.upper_bound),
+            fmtDurationSigned(new_interval.upper_bound - new_interval.lower_bound),
+        });
+
+        const elapsed = @intCast(i64, self.epoch.elapsed(self));
+        const system = self.time.realtime();
+        const lower = self.epoch.realtime + elapsed + new_interval.lower_bound;
+        const upper = self.epoch.realtime + elapsed + new_interval.upper_bound;
+        const cluster = std.math.clamp(system, lower, upper);
+
+        if (system == cluster) {
+            log.info("system time is within cluster time", .{});
+        } else if (system < lower) {
+            log.err("system time is {} behind, clamping system time to cluster time", .{
+                fmtDurationSigned(lower - system),
+            });
+        } else {
+            log.err("system time is {} ahead, clamping system time to cluster time", .{
+                fmtDurationSigned(system - upper),
+            });
+        }
+
+        if (old_epoch_synchronized) |old_interval| {
+            const a = old_interval.upper_bound - old_interval.lower_bound;
+            const b = new_interval.upper_bound - new_interval.lower_bound;
+            if (b > a) {
+                log.notice("clock sources required {} more tolerance to synchronize", .{
+                    std.fmt.fmtDuration(@intCast(u64, b - a)),
+                });
+            }
+        }
+    }
+
+    fn window_tuples(self: *Self, tolerance: u64) []Marzullo.Tuple {
+        assert(self.window.sources[self.replica].?.clock_offset == 0);
+        assert(self.window.sources[self.replica].?.one_way_delay == 0);
         var count: usize = 0;
-        for (self.sources) |sampled, source| {
+        for (self.window.sources) |sampled, source| {
             if (sampled) |sample| {
-                const range = @intCast(i64, sample.one_way_delay) + @intCast(i64, clock_offset_max);
                 self.marzullo_tuples[count] = Marzullo.Tuple{
                     .source = @intCast(u8, source),
-                    .offset = sample.clock_offset - range,
+                    .offset = sample.clock_offset - @intCast(i64, sample.one_way_delay + tolerance),
                     .bound = .lower,
                 };
                 count += 1;
                 self.marzullo_tuples[count] = Marzullo.Tuple{
                     .source = @intCast(u8, source),
-                    .offset = sample.clock_offset + range,
+                    .offset = sample.clock_offset + @intCast(i64, sample.one_way_delay + tolerance),
                     .bound = .upper,
                 };
                 count += 1;
@@ -203,38 +329,132 @@ pub const Clock = struct {
         }
         return self.marzullo_tuples[0..count];
     }
+
+    fn minimum_one_way_delay(a: ?Sample, b: ?Sample) ?Sample {
+        if (a == null) return b;
+        if (b == null) return a;
+        if (a.?.one_way_delay < b.?.one_way_delay) return a;
+        // Choose B if B's one way delay is less or the same (we assume B is the newer sample):
+        return b;
+    }
 };
 
-// TODO Each Clock instance should accept a Time instance that can be ticked deterministically for
-// testing purposes, and which will expose the following two timestamps:
-// This is the same pattern we use for Journal (all the logic) and Storage (the raw read/write).
+pub const SystemTime = struct {
+    const Self = @This();
 
-/// A timestamp to measure elapsed time, meaningful only on the same system, not across reboots.
-/// Always use a monotonic timestamp if the goal is to measure elapsed time.
-/// This clock is not affected by discontinuous jumps in the system time, for example if the
-/// system administrator manually changes the clock.
-fn monotonic_timestamp() u64 {
-    // The true monotonic clock on Linux is not in fact CLOCK_MONOTONIC:
-    // CLOCK_MONOTONIC excludes elapsed time while the system is suspended (e.g. VM migration).
-    // CLOCK_BOOTTIME is the same as CLOCK_MONOTONIC but includes elapsed time during a suspend.
-    // For more detail and why CLOCK_MONOTONIC_RAW is even worse than CLOCK_MONOTONIC,
-    // see https://github.com/ziglang/zig/pull/933#discussion_r656021295.
-    var ts: std.os.timespec = undefined;
-    std.os.clock_gettime(std.os.CLOCK_BOOTTIME, &ts) catch unreachable;
-    const m = @intCast(u64, ts.tv_sec) * @as(u64, std.time.ns_per_s) + @intCast(u64, ts.tv_nsec);
-    assert(m >= monotonic_timestamp_guard);
-    monotonic_timestamp_guard = m;
-    return m;
+    /// Hardware and/or software bugs can mean that the monotonic clock may regress.
+    /// One example (of many): https://bugzilla.redhat.com/show_bug.cgi?id=448449
+    /// We crash the process for safety if this ever happens, to protect against infinite loops.
+    /// It's better to crash and come back with a valid monotonic clock than get stuck forever.
+    monotonic_guard: u64 = 0,
+
+    /// A timestamp to measure elapsed time, meaningful only on the same system, not across reboots.
+    /// Always use a monotonic timestamp if the goal is to measure elapsed time.
+    /// This clock is not affected by discontinuous jumps in the system time, for example if the
+    /// system administrator manually changes the clock.
+    pub fn monotonic(self: *Self) u64 {
+        // The true monotonic clock on Linux is not in fact CLOCK_MONOTONIC:
+        // CLOCK_MONOTONIC excludes elapsed time while the system is suspended (e.g. VM migration).
+        // CLOCK_BOOTTIME is the same as CLOCK_MONOTONIC but includes elapsed time during a suspend.
+        // For more detail and why CLOCK_MONOTONIC_RAW is even worse than CLOCK_MONOTONIC,
+        // see https://github.com/ziglang/zig/pull/933#discussion_r656021295.
+        var ts: std.os.timespec = undefined;
+        std.os.clock_gettime(std.os.CLOCK_BOOTTIME, &ts) catch unreachable;
+        const m = @intCast(u64, ts.tv_sec) * std.time.ns_per_s + @intCast(u64, ts.tv_nsec);
+        assert(m >= self.monotonic_guard);
+        self.monotonic_guard = m;
+        return m;
+    }
+
+    /// A timestamp to measure real (i.e. wall clock) time, meaningful across systems, and reboots.
+    /// This clock is affected by discontinuous jumps in the system time.
+    pub fn realtime(self: *Self) i64 {
+        var ts: std.os.timespec = undefined;
+        std.os.clock_gettime(std.os.CLOCK_REALTIME, &ts) catch unreachable;
+        return @as(i64, ts.tv_sec) * std.time.ns_per_s + ts.tv_nsec;
+    }
+
+    pub fn tick(self: *Self) void {}
+};
+
+pub const DeterministicTime = struct {
+    const Self = @This();
+
+    /// The duration of a single tick in nanoseconds.
+    resolution: u64,
+
+    /// The number of ticks elapsed since initialization.
+    ticks: u64 = 0,
+
+    /// The instant in time chosen as the origin of this time source.
+    epoch: i64 = 0,
+
+    pub fn monotonic(self: *Self) u64 {
+        return self.ticks * self.resolution;
+    }
+
+    pub fn realtime(self: *Self) i64 {
+        return self.epoch + @intCast(i64, self.monotonic());
+    }
+
+    pub fn tick(self: *Self) void {
+        self.ticks += 1;
+    }
+};
+
+/// Return a Formatter for a signed number of nanoseconds according to magnitude:
+/// [#y][#w][#d][#h][#m]#[.###][n|u|m]s
+pub fn fmtDurationSigned(ns: i64) std.fmt.Formatter(formatDurationSigned) {
+    return .{ .data = ns };
 }
 
-/// Hardware and/or software bugs can mean that the monotonic clock may regress.
-/// One example (of many): https://bugzilla.redhat.com/show_bug.cgi?id=448449
-var monotonic_timestamp_guard: u64 = 0;
+fn formatDurationSigned(
+    ns: i64,
+    comptime fmt: []const u8,
+    options: std.fmt.FormatOptions,
+    writer: anytype,
+) !void {
+    if (ns < 0) {
+        try writer.print("-{}", .{std.fmt.fmtDuration(@intCast(u64, -ns))});
+    } else {
+        try writer.print("{}", .{std.fmt.fmtDuration(@intCast(u64, ns))});
+    }
+}
 
-/// A timestamp to measure real (i.e. wall clock) time, meaningful across systems, and reboots.
-/// This clock is affected by discontinuous jumps in the system time.
-fn realtime_timestamp() i64 {
-    var ts: std.os.timespec = undefined;
-    std.os.clock_gettime(std.os.CLOCK_REALTIME, &ts) catch unreachable;
-    return @intCast(i64, ts.tv_sec) * @as(i64, std.time.ns_per_s) + @intCast(i64, ts.tv_nsec);
+// TODO Use tracing analysis to test a simulated trace, comparing against known values for accuracy.
+fn test_simple() !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = &arena.allocator;
+
+    const replica_count = 3;
+    const replica = 0;
+    var time = DeterministicTime{ .resolution = std.time.ns_per_s };
+
+    var clock = try Clock.init(allocator, replica_count, replica, &time);
+
+    const m0 = clock.window.monotonic;
+    const t1 = clock.window.realtime + (50 + 500) * std.time.ns_per_ms;
+    const m2 = clock.window.monotonic + 100 * std.time.ns_per_ms;
+
+    clock.learn(1, m0, t1, m2);
+    clock.learn(2, m0, t1, m2);
+
+    var sync_again = true;
+
+    while (clock.time.ticks < 100) {
+        std.time.sleep(config.tick_ms * std.time.ns_per_ms);
+        clock.tick();
+
+        if (clock.realtime_synchronized() != null and sync_again) {
+            sync_again = false;
+
+            const bm0 = clock.window.monotonic;
+            const bt1 = clock.window.realtime + (50 + 500) * std.time.ns_per_ms;
+            const bm2 = clock.window.monotonic + 100 * std.time.ns_per_ms;
+
+            clock.learn(1, bm0, bt1, bm2);
+            clock.learn(2, bm0, bt1 + (500) * std.time.ns_per_ms, bm2);
+        }
+    }
 }

--- a/src/clock.zig
+++ b/src/clock.zig
@@ -1,0 +1,235 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+const Marzullo = @import("marzullo.zig").Marzullo;
+
+const Sample = struct {
+    clock_offset: i64,
+    one_way_delay: u64,
+};
+
+pub const Clock = struct {
+    allocator: *std.mem.Allocator,
+    replica: u8,
+    sources: []?Sample,
+    clock_offset_max: u64,
+    window_duration_min: u64,
+    window_duration_max: u64,
+    window_epoch_monotonic: u64,
+    window_epoch_realtime: i64,
+    marzullo_tuples: []Marzullo.Tuple,
+    epoch_monotonic: ?u64 = null,
+    epoch_realtime: ?i64 = null,
+    epoch_clock_offset: ?i64 = null,
+
+    pub fn init(
+        allocator: *std.mem.Allocator,
+        replica_count: u8,
+        replica: u8,
+    ) !Clock {
+        assert(replica_count > 0);
+        assert(replica < replica_count);
+
+        var sources = try allocator.alloc(?Sample, replica_count);
+        errdefer allocator.free(sources);
+
+        // There are two Marzullo tuple bounds (lower and upper) per source clock offset sample:
+        var marzullo_tuples = try allocator.alloc(Marzullo.Tuple, sources.len * 2);
+        errdefer allocator.free(marzullo_tuples);
+
+        var self = Clock{
+            .allocator = allocator,
+            .replica = replica,
+            .sources = sources,
+            .clock_offset_max = 10 * std.time.ns_per_s,
+            .window_duration_min = 2 * std.time.ns_per_s,
+            .window_duration_max = 8 * std.time.ns_per_s,
+            .window_epoch_monotonic = undefined,
+            .window_epoch_realtime = undefined,
+            .marzullo_tuples = marzullo_tuples,
+        };
+        self.open_new_window();
+        return self;
+    }
+
+    /// Called by `Replica.on_pong()` with:
+    /// * the index of the `replica` we pinged that has now ponged back,
+    /// * our monotonic timestamp `m0` embedded in the ping we sent, copied over to the pong reply,
+    /// * the remote replica's `realtime()` timestamp `t1`, and
+    /// * our monotonic timestamp `m2` as captured by the `Replica.on_pong()` handler.
+    pub fn learn_from_roundtrip(self: *Clock, replica: u8, m0: u64, t1: i64, m2: u64) void {
+        assert(replica != self.replica);
+
+        if (m0 >= m2) return;
+        // TODO We may receive delayed packets after a reboot, in which case m0/m2 will be invalid.
+        // We should add a 128-bit identifier to ping/pongs to bind them to the current window.
+        if (m0 < self.window_epoch_monotonic) return;
+        if (m2 < self.window_epoch_monotonic) return;
+        const window_elapsed: u64 = m2 - self.window_epoch_monotonic;
+        if (window_elapsed > self.window_duration_max) return;
+
+        const round_trip_time: u64 = m2 - m0;
+        const one_way_delay: u64 = round_trip_time / 2;
+        const t2: i64 = self.window_epoch_realtime + @intCast(i64, window_elapsed);
+        const clock_offset: i64 = t1 + @intCast(i64, one_way_delay) - t2;
+
+        // TODO Correct asymmetric error when we can see it's there.
+        // "A System for Clock Synchronization in an Internet of Things"
+
+        self.sources[replica] = choose_minimum_one_way_delay(self.sources[replica], Sample{
+            .clock_offset = clock_offset,
+            .one_way_delay = one_way_delay,
+        });
+
+        self.close_window();
+    }
+
+    /// Called by `Replica.on_ping_timeout()` to provide `m0` when a replica decides to send a ping.
+    /// Called by `Replica.on_pong()` to provide `m2` when the replica receives the pong.
+    pub fn monotonic(self: *Clock) u64 {
+        return monotonic_timestamp();
+    }
+
+    /// Called by `Replica.on_ping()` when responding to a ping with a pong.
+    /// We use synchronized time if possible, so that the cluster remembers true time as a whole.
+    /// We fall back to our wall clock if we do not have synchronized time.
+    pub fn realtime(self: *Clock) i64 {
+        if (self.synchronized()) |realtime| {
+            return realtime;
+        } else {
+            return realtime_timestamp();
+        }
+    }
+
+    /// Called by `StateMachine.prepare_timestamp()` when the leader wants to timestamp a batch.
+    /// If the leader's clock is not synchronized with the cluster, it will wait until it is.
+    pub fn realtime_synchronized(self: *Clock) ?i64 {
+        if (self.epoch_clock_offset) |clock_offset| {
+            // TODO We can alternatively compare our estimated time with NTP and prefer NTP
+            // provided it is within our synchronized bounds.
+            // This means that installations with more accurate time sources will use those, and we
+            // have guardrails and defense in depth if those time sources fail.
+            const epoch_elapsed = monotonic_timestamp() - self.epoch_monotonic.?;
+            return self.epoch_realtime.? + clock_offset + @intCast(i64, epoch_elapsed);
+        } else {
+            return null;
+        }
+    }
+
+    pub fn tick(self: *Clock) void {
+        self.close_window();
+    }
+
+    /// Round trip delay is the biggest component of estimation error, so we choose the smallest.
+    fn choose_minimum_one_way_delay(a: ?Sample, b: ?Sample) ?Sample {
+        if (a == null) return b;
+        if (b == null) return a;
+        if (a.?.one_way_delay < b.?.one_way_delay) return a;
+        // Choose B if B's one way delay is less or the same (we assume B is the newer sample):
+        return b;
+    }
+
+    fn close_window(self: *Clock) void {
+        const window_elapsed = monotonic_timestamp() - self.window_epoch_monotonic;
+        if (window_elapsed < self.window_duration_min) return;
+        if (window_elapsed >= self.window_duration_max) {
+            // TODO Warn that our window expired.
+            self.open_new_window();
+            return;
+        }
+
+        if (self.synchronize_window()) |interval| {
+            assert(interval.sources_true > @divTrunc(self.sources.len, 2));
+
+            self.epoch_monotonic = self.window_epoch_monotonic;
+            self.epoch_realtime = self.window_epoch_realtime;
+            self.epoch_clock_offset = interval.lower_bound;
+
+            // TODO Add debug logs.
+            self.open_new_window();
+        }
+    }
+
+    fn open_new_window(self: *Clock) void {
+        std.mem.set(?Sample, self.sources, null);
+        self.sources[self.replica] = Sample{
+            .clock_offset = 0,
+            .one_way_delay = 0,
+        };
+        self.window_epoch_monotonic = monotonic_timestamp();
+        self.window_epoch_realtime = realtime_timestamp();
+        std.mem.set(Marzullo.Tuple, self.marzullo_tuples, undefined);
+    }
+
+    fn synchronize_window(self: *Clock) ?Marzullo.Interval {
+        const window_elapsed = monotonic_timestamp() - self.window_epoch_monotonic;
+        if (window_elapsed < self.window_duration_min) return null;
+
+        // Starting with the most clock offset tolerance, while we have a majority, find the best
+        // smallest interval with the least clock offset tolerance, reducing tolerance at each step:
+        var best: ?Marzullo.Interval = null;
+
+        var tolerance = self.clock_offset_max;
+        while (tolerance > 0) : (tolerance /= 16) {
+            var interval = Marzullo.smallest_interval(self.window_tuples(tolerance));
+            const majority = interval.sources_true > @divTrunc(self.sources.len, 2);
+            if (!majority) break;
+            best = interval;
+        }
+
+        return best;
+    }
+
+    fn window_tuples(self: *Clock, clock_offset_max: u64) []Marzullo.Tuple {
+        assert(self.sources[self.replica].?.clock_offset == 0);
+        assert(self.sources[self.replica].?.one_way_delay == 0);
+        var count: usize = 0;
+        for (self.sources) |sampled, source| {
+            if (sampled) |sample| {
+                const range = @intCast(i64, sample.one_way_delay) + @intCast(i64, clock_offset_max);
+                self.marzullo_tuples[count] = Marzullo.Tuple{
+                    .source = @intCast(u8, source),
+                    .offset = sample.clock_offset - range,
+                    .bound = .lower,
+                };
+                count += 1;
+                self.marzullo_tuples[count] = Marzullo.Tuple{
+                    .source = @intCast(u8, source),
+                    .offset = sample.clock_offset + range,
+                    .bound = .upper,
+                };
+                count += 1;
+            }
+        }
+        return self.marzullo_tuples[0..count];
+    }
+};
+
+// TODO Each Clock instance should accept a Time instance that can be ticked deterministically for
+// testing purposes, and which will expose the following two timestamps:
+// This is the same pattern we use for Journal (all the logic) and Storage (the raw read/write).
+
+/// A timestamp to measure elapsed time, meaningful only on the same system, not across reboots.
+/// Always use a monotonic timestamp if the goal is to measure elapsed time.
+/// This clock is not affected by discontinuous jumps in the system time, for example if the
+/// system administrator manually changes the clock.
+fn monotonic_timestamp() u64 {
+    // The true monotonic clock on Linux is not in fact CLOCK_MONOTONIC:
+    // CLOCK_MONOTONIC excludes elapsed time while the system is suspended (e.g. VM migration).
+    // CLOCK_BOOTTIME is the same as CLOCK_MONOTONIC but includes elapsed time during a suspend.
+    // For more detail and why CLOCK_MONOTONIC_RAW is even worse than CLOCK_MONOTONIC,
+    // see https://github.com/ziglang/zig/pull/933#discussion_r656021295.
+    var ts: std.os.timespec = undefined;
+    std.os.clock_gettime(std.os.CLOCK_BOOTTIME, &ts) catch unreachable;
+    return @intCast(u64, ts.tv_sec) * @as(u64, std.time.ns_per_s) + @intCast(u64, ts.tv_nsec);
+
+    // TODO Add a monotonic guard here to verify that clock is monotonic.
+}
+
+/// A timestamp to measure real (i.e. wall clock) time, meaningful across systems, and reboots.
+/// This clock is affected by discontinuous jumps in the system time.
+fn realtime_timestamp() i64 {
+    var ts: std.os.timespec = undefined;
+    std.os.clock_gettime(std.os.CLOCK_REALTIME, &ts) catch unreachable;
+    return @intCast(i64, ts.tv_sec) * @as(i64, std.time.ns_per_s) + @intCast(i64, ts.tv_nsec);
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -165,16 +165,10 @@ pub const direct_io = true;
 /// Used to regulate heartbeats, retries and timeouts, all specified as multiples of a tick.
 pub const tick_ms = 10;
 
-/// TODO We need to switch to nanoseconds for these tolerances, so that we can express microseconds:
-/// We are currently more accurate than a millisecond on a local cluster.
-/// The minimum skew between two clocks to allow when considering them to be in agreement.
-/// Decreasing this increases the probability of clamping the system time to the cluster time.
-/// Increasing this reduces the accuracy of synchronized time.
-pub const clock_offset_tolerance_min_ms = 1;
-
 /// The maximum skew between two clocks to allow when considering them to be in agreement.
 /// The principle is that no two clocks tick exactly alike but some clocks more or less agree.
 /// The maximum skew across the cluster as a whole is this value times the total number of clocks.
+/// The cluster will be unavailable if the majority of clocks are all further than this value apart.
 /// Decreasing this reduces the probability of reaching agreement on synchronized time.
 /// Increasing this reduces the accuracy of synchronized time.
 pub const clock_offset_tolerance_max_ms = 10000;

--- a/src/config.zig
+++ b/src/config.zig
@@ -165,12 +165,19 @@ pub const direct_io = true;
 /// Used to regulate heartbeats, retries and timeouts, all specified as multiples of a tick.
 pub const tick_ms = 10;
 
-/// The maximum skew between two clocks to allow while considering them to be in agreement.
+/// TODO We need to switch to nanoseconds for these tolerances, so that we can express microseconds:
+/// We are currently more accurate than a millisecond on a local cluster.
+/// The minimum skew between two clocks to allow when considering them to be in agreement.
+/// Decreasing this increases the probability of clamping the system time to the cluster time.
+/// Increasing this reduces the accuracy of synchronized time.
+pub const clock_offset_tolerance_min_ms = 1;
+
+/// The maximum skew between two clocks to allow when considering them to be in agreement.
 /// The principle is that no two clocks tick exactly alike but some clocks more or less agree.
 /// The maximum skew across the cluster as a whole is this value times the total number of clocks.
 /// Decreasing this reduces the probability of reaching agreement on synchronized time.
 /// Increasing this reduces the accuracy of synchronized time.
-pub const clock_offset_tolerance_max_ms = 1000;
+pub const clock_offset_tolerance_max_ms = 10000;
 
 /// The amount of time before the clock's synchronized epoch is expired.
 /// If the epoch is expired before it can be replaced with a new synchronized epoch, then this most

--- a/src/config.zig
+++ b/src/config.zig
@@ -164,3 +164,28 @@ pub const direct_io = true;
 /// The number of milliseconds between each replica tick, the basic unit of time in TigerBeetle.
 /// Used to regulate heartbeats, retries and timeouts, all specified as multiples of a tick.
 pub const tick_ms = 10;
+
+/// The maximum skew between two clocks to allow while considering them to be in agreement.
+/// The principle is that no two clocks tick exactly alike but some clocks more or less agree.
+/// The maximum skew across the cluster as a whole is this value times the total number of clocks.
+/// Decreasing this reduces the probability of reaching agreement on synchronized time.
+/// Increasing this reduces the accuracy of synchronized time.
+pub const clock_offset_tolerance_max_ms = 1000;
+
+/// The amount of time before the clock's synchronized epoch is expired.
+/// If the epoch is expired before it can be replaced with a new synchronized epoch, then this most
+/// likely indicates either a network partition or else too many clock faults across the cluster.
+/// A new synchronized epoch will be installed as soon as these conditions resolve.
+pub const clock_epoch_max_ms = 60000;
+
+/// The amount of time to wait for enough accurate samples before synchronizing the clock.
+/// The more samples we can take per remote clock source, the more accurate our estimation becomes.
+/// This impacts cluster startup time as the leader must first wait for synchronization to complete.
+pub const clock_synchronization_window_min_ms = 2000;
+
+/// The amount of time without agreement before the clock window is expired and a new window opened.
+/// This happens where some samples have been collected but not enough to reach agreement.
+/// The quality of samples degrades as they age so at some point we throw them away and start over.
+/// This eliminates the impact of gradual clock drift on our clock offset (clock skew) measurements.
+/// If a window expires because of this then it is likely that the clock epoch will also be expired.
+pub const clock_synchronization_window_max_ms = 20000;

--- a/src/main.zig
+++ b/src/main.zig
@@ -12,6 +12,7 @@ const StateMachine = @import("state_machine.zig").StateMachine;
 
 const vr = @import("vr.zig");
 const Replica = vr.Replica;
+const SystemTime = vr.SystemTime;
 const Journal = vr.Journal;
 
 pub fn main() !void {
@@ -27,6 +28,7 @@ pub fn main() !void {
         config.transfers_max,
         config.commits_max,
     );
+    var time = SystemTime{};
     var storage = try Storage.init(arena, config.journal_size_max);
     var journal = try Journal.init(
         arena,
@@ -47,6 +49,7 @@ pub fn main() !void {
         args.cluster,
         @intCast(u16, args.configuration.len),
         args.replica,
+        &time,
         &journal,
         &message_bus,
         &state_machine,

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,13 +6,13 @@ pub const log_level: std.log.Level = @intToEnum(std.log.Level, config.log_level)
 const cli = @import("cli.zig");
 
 const IO = @import("io.zig").IO;
+const Time = @import("time.zig").Time;
 const Storage = @import("storage.zig").Storage;
 const MessageBus = @import("message_bus.zig").MessageBusReplica;
 const StateMachine = @import("state_machine.zig").StateMachine;
 
 const vr = @import("vr.zig");
 const Replica = vr.Replica;
-const SystemTime = vr.SystemTime;
 const Journal = vr.Journal;
 
 pub fn main() !void {
@@ -28,7 +28,7 @@ pub fn main() !void {
         config.transfers_max,
         config.commits_max,
     );
-    var time = SystemTime{};
+    var time = Time{};
     var storage = try Storage.init(arena, config.journal_size_max);
     var journal = try Journal.init(
         arena,

--- a/src/marzullo.zig
+++ b/src/marzullo.zig
@@ -1,0 +1,289 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+/// Marzullo's algorithm, invented by Keith Marzullo for his Ph.D. dissertation in 1984, is an
+/// agreement algorithm used to select sources for estimating accurate time from a number of noisy
+/// time sources. NTP uses a modified form of this called the Intersection algorithm, which returns
+/// a larger interval for further statistical sampling. However, here we want the smallest interval.
+pub const Marzullo = struct {
+
+    /// The smallest interval consistent with the largest number of sources.
+    pub const Interval = struct {
+        /// The lower bound on the minimum clock offset.
+        lower_bound: i64,
+
+        /// The upper bound on the maximum clock offset.
+        upper_bound: i64,
+
+        /// The number of "true chimers" consistent with the largest number of sources.
+        sources_true: u8,
+
+        /// The number of "false chimers" falling outside this interval.
+        /// Where `sources_false` plus `sources_true` always equals the total number of sources.
+        sources_false: u8,
+
+        /// Whether the largest number of sources in this interval also constitutes a majority.
+        /// For example, if a replica is a member of a cluster of 5 replicas and samples the clock
+        /// offsets of 4 remote replicas (so that `sources=4`), then a majority will consist of at
+        /// least 3 of these remote replica sources being in agreement.
+        /// This implies that a cluster of 3 replicas requires all 3 replicas to be alive in order
+        /// to estimate a majority interval on the cluster time. We cannot have agreement if
+        /// 1 replica is down, because there is no tiebreaker between the remaining two replicas.
+        pub fn majority(self: *Interval) bool {
+            const sources = self.sources_true + self.sources_false;
+            return self.sources_true > @divTrunc(sources, 2);
+        }
+    };
+
+    /// A tuple represents either the lower or upper end of a bound, and is fed as input to the
+    /// Marzullo algorithm to compute the smallest interval across all tuples.
+    /// For example, given a clock offset to a remote replica of 3s and a round trip time of 1s,
+    /// we might create two tuples, the lower bound having an offset of 2.5s and the upper bound
+    /// having an offset of 3.5s, to represent the error introduced by the round trip time.
+    pub const Tuple = struct {
+        source: u8,
+        offset: i64,
+        bound: enum {
+            lower,
+            upper,
+        },
+    };
+
+    /// Returns the smallest interval consistent with the largest number of sources.
+    pub fn smallest_interval(tuples: []Tuple) Interval {
+        // There are two bounds (lower and upper) per clock offset sample.
+        const bounds = 2;
+
+        const sources = @divExact(tuples.len, bounds);
+        assert(sources <= std.math.maxInt(u8));
+
+        if (sources == 0) {
+            assert(tuples.len == 0);
+            return Interval{
+                .lower_bound = 0,
+                .upper_bound = 0,
+                .sources_true = 0,
+                .sources_false = 0,
+            };
+        }
+
+        std.sort.insertionSort(Tuple, tuples, {}, less_than);
+
+        // Double-check that our sort implementation is working correctly:
+        // TODO Assert that each source appears at most once, so that we don't double-count sources.
+        var last_tuple: ?Tuple = null;
+        for (tuples) |b, i| {
+            if (last_tuple) |a| {
+                assert(a.offset <= b.offset);
+                if (a.offset == b.offset and a.source == b.source) {
+                    assert(a.bound == .lower and b.bound == .upper);
+                }
+            }
+            last_tuple = b;
+        }
+        assert(last_tuple.?.bound == .upper);
+
+        // Here is a description of the algorithm:
+        // https://en.wikipedia.org/wiki/Marzullo%27s_algorithm#Method
+        var best: i64 = 0;
+        var count: i64 = 0;
+
+        var interval = Interval{
+            .lower_bound = undefined,
+            .upper_bound = undefined,
+            .sources_true = 0,
+            .sources_false = 0,
+        };
+
+        for (tuples) |tuple, i| {
+            // Update the current number of overlapping intervals:
+            count -= switch (tuple.bound) {
+                .lower => @as(i64, -1),
+                .upper => @as(i64, 1),
+            };
+            // The last upper bound tuple will have a count of one less than the lower bound.
+            // Therefore, we should never see count >= best for the last tuple:
+            if (count > best) {
+                best = count;
+                interval.lower_bound = tuple.offset;
+                interval.upper_bound = tuples[i + 1].offset;
+            } else if (count == best and tuples[i + 1].bound == .upper) {
+                // This is a tie for best overlap. Both intervals have the same number of sources.
+                // We want to choose the smaller of the two intervals:
+                const alternative = tuples[i + 1].offset - tuples[i].offset;
+                if (alternative < interval.upper_bound - interval.lower_bound) {
+                    interval.lower_bound = tuples[i].offset;
+                    interval.upper_bound = tuples[i + 1].offset;
+                }
+            }
+        }
+
+        // The number of false sources (ones which do not overlap the optimal interval) is the
+        // number of sources minus the value of `best`:
+        assert(best >= 0);
+        assert(best <= sources);
+        interval.sources_true = @intCast(u8, best);
+        interval.sources_false = @intCast(u8, sources - @intCast(u8, best));
+        assert(interval.sources_true + interval.sources_false == sources);
+
+        return interval;
+    }
+
+    /// Sorts the list of tuples by clock offset. If two tuples with the same offset but opposite
+    /// bounds exist, indicating that one interval ends just as another begins, then a method of
+    /// deciding which comes first is necessary. Such an occurrence can be considered an overlap
+    /// with no duration, which can be found by the algorithm by sorting the lower bound before the
+    /// upper bound. Alternatively, if such pathological overlaps are considered objectionable then
+    /// they can be avoided by sorting the upper bound before the lower bound.
+    fn less_than(context: void, a: Tuple, b: Tuple) bool {
+        if (a.offset < b.offset) return true;
+        if (b.offset < a.offset) return false;
+        if (a.bound == .lower and b.bound == .upper) return true;
+        if (b.bound == .lower and a.bound == .upper) return false;
+        if (a.source < b.source) return true;
+        if (b.source < a.source) return false;
+        return false;
+    }
+};
+
+fn test_smallest_interval_and_majority(
+    bounds: []const i64,
+    smallest_interval: Marzullo.Interval,
+    majority: bool,
+) !void {
+    const testing = std.testing;
+
+    var arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_allocator.deinit();
+    const allocator = &arena_allocator.allocator;
+
+    var tuples = try allocator.alloc(Marzullo.Tuple, bounds.len);
+    for (bounds) |bound, i| {
+        tuples[i] = .{
+            .source = @intCast(u8, @divTrunc(i, 2)),
+            .offset = bound,
+            .bound = if (i % 2 == 0) .lower else .upper,
+        };
+    }
+
+    var interval = Marzullo.smallest_interval(tuples);
+    try testing.expectEqual(smallest_interval, interval);
+    try testing.expectEqual(true, interval.majority());
+}
+
+test {
+    const testing = std.testing;
+    const Interval = Marzullo.Interval;
+    const Tuple = Marzullo.Tuple;
+
+    try test_smallest_interval_and_majority(
+        &[_]i64{
+            8,  12,
+            11, 13,
+            10, 12,
+        },
+        Interval{
+            .lower_bound = 11,
+            .upper_bound = 12,
+            .sources_true = 3,
+            .sources_false = 0,
+        },
+        true,
+    );
+
+    try test_smallest_interval_and_majority(
+        &[_]i64{
+            8,  12,
+            11, 13,
+            14, 15,
+        },
+        Interval{
+            .lower_bound = 11,
+            .upper_bound = 12,
+            .sources_true = 2,
+            .sources_false = 1,
+        },
+        true,
+    );
+
+    try test_smallest_interval_and_majority(
+        &[_]i64{
+            -10, 10,
+            -1,  1,
+            0,   0,
+        },
+        Interval{
+            .lower_bound = 0,
+            .upper_bound = 0,
+            .sources_true = 3,
+            .sources_false = 0,
+        },
+        true,
+    );
+
+    // The upper bound of the first interval overlaps inclusively with the lower of the last.
+    try test_smallest_interval_and_majority(
+        &[_]i64{
+            8,  10,
+            8,  12,
+            10, 11,
+        },
+        Interval{
+            .lower_bound = 10,
+            .upper_bound = 10,
+            .sources_true = 3,
+            .sources_false = 0,
+        },
+        true,
+    );
+
+    // The first smallest interval is selected. The alternative with equal overlap is 10..12.
+    // However, while this shares the same number of sources, it is not the smallest interval.
+    try test_smallest_interval_and_majority(
+        &[_]i64{
+            8,  9,
+            8,  12,
+            10, 12,
+        },
+        Interval{
+            .lower_bound = 8,
+            .upper_bound = 9,
+            .sources_true = 2,
+            .sources_false = 1,
+        },
+        true,
+    );
+
+    // The last smallest interval is selected. The alternative with equal overlap is 7..9.
+    // However, while this shares the same number of sources, it is not the smallest interval.
+    try test_smallest_interval_and_majority(
+        &[_]i64{
+            7,  9,
+            7,  12,
+            10, 11,
+        },
+        Interval{
+            .lower_bound = 10,
+            .upper_bound = 11,
+            .sources_true = 2,
+            .sources_false = 1,
+        },
+        true,
+    );
+
+    // The same idea as the previous test, but with negative offsets.
+    try test_smallest_interval_and_majority(
+        &[_]i64{
+            -9,  -7,
+            -12, -7,
+            -11, -10,
+        },
+        Interval{
+            .lower_bound = -11,
+            .upper_bound = -10,
+            .sources_true = 2,
+            .sources_false = 1,
+        },
+        true,
+    );
+}

--- a/src/marzullo.zig
+++ b/src/marzullo.zig
@@ -158,8 +158,6 @@ fn test_smallest_interval_and_majority(
     smallest_interval: Marzullo.Interval,
     majority: bool,
 ) !void {
-    const testing = std.testing;
-
     var arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena_allocator.deinit();
     const allocator = &arena_allocator.allocator;
@@ -174,22 +172,18 @@ fn test_smallest_interval_and_majority(
     }
 
     var interval = Marzullo.smallest_interval(tuples);
-    try testing.expectEqual(smallest_interval, interval);
-    try testing.expectEqual(majority, interval.majority());
+    try std.testing.expectEqual(smallest_interval, interval);
+    try std.testing.expectEqual(majority, interval.majority());
 }
 
 test {
-    const testing = std.testing;
-    const Interval = Marzullo.Interval;
-    const Tuple = Marzullo.Tuple;
-
     try test_smallest_interval_and_majority(
         &[_]i64{
             11, 13,
             10, 12,
             8,  12,
         },
-        Interval{
+        Marzullo.Interval{
             .lower_bound = 11,
             .upper_bound = 12,
             .sources_true = 3,
@@ -204,7 +198,7 @@ test {
             11, 13,
             14, 15,
         },
-        Interval{
+        Marzullo.Interval{
             .lower_bound = 11,
             .upper_bound = 12,
             .sources_true = 2,
@@ -219,7 +213,7 @@ test {
             -1,  1,
             0,   0,
         },
-        Interval{
+        Marzullo.Interval{
             .lower_bound = 0,
             .upper_bound = 0,
             .sources_true = 3,
@@ -235,7 +229,7 @@ test {
             10, 11,
             8,  10,
         },
-        Interval{
+        Marzullo.Interval{
             .lower_bound = 10,
             .upper_bound = 10,
             .sources_true = 3,
@@ -252,7 +246,7 @@ test {
             10, 12,
             8,  9,
         },
-        Interval{
+        Marzullo.Interval{
             .lower_bound = 8,
             .upper_bound = 9,
             .sources_true = 2,
@@ -269,7 +263,7 @@ test {
             7,  12,
             10, 11,
         },
-        Interval{
+        Marzullo.Interval{
             .lower_bound = 10,
             .upper_bound = 11,
             .sources_true = 2,
@@ -285,7 +279,7 @@ test {
             -12, -7,
             -11, -10,
         },
-        Interval{
+        Marzullo.Interval{
             .lower_bound = -11,
             .upper_bound = -10,
             .sources_true = 2,
@@ -297,7 +291,7 @@ test {
     // A cluster of one with no remote sources.
     try test_smallest_interval_and_majority(
         &[_]i64{},
-        Interval{
+        Marzullo.Interval{
             .lower_bound = 0,
             .upper_bound = 0,
             .sources_true = 0,
@@ -311,7 +305,7 @@ test {
         &[_]i64{
             1, 3,
         },
-        Interval{
+        Marzullo.Interval{
             .lower_bound = 0,
             .upper_bound = 0,
             .sources_true = 1,
@@ -326,7 +320,7 @@ test {
             1, 3,
             2, 2,
         },
-        Interval{
+        Marzullo.Interval{
             .lower_bound = 2,
             .upper_bound = 2,
             .sources_true = 2,
@@ -341,7 +335,7 @@ test {
             1, 3,
             4, 5,
         },
-        Interval{
+        Marzullo.Interval{
             .lower_bound = 4,
             .upper_bound = 5,
             .sources_true = 1,

--- a/src/marzullo.zig
+++ b/src/marzullo.zig
@@ -41,7 +41,7 @@ pub const Marzullo = struct {
 
     /// Returns the smallest interval consistent with the largest number of sources.
     pub fn smallest_interval(tuples: []Tuple) Interval {
-        // There are two bounds (lower and upper) per clock offset source sample.
+        // There are two bounds (lower and upper) per source clock offset sample.
         const sources = @intCast(u8, @divExact(tuples.len, 2));
 
         if (sources == 0) {

--- a/src/marzullo.zig
+++ b/src/marzullo.zig
@@ -48,9 +48,10 @@ pub const Marzullo = struct {
 
     /// A tuple represents either the lower or upper end of a bound, and is fed as input to the
     /// Marzullo algorithm to compute the smallest interval across all tuples.
-    /// For example, given a clock offset to a remote replica of 3s and a round trip time of 1s,
-    /// we might create two tuples, the lower bound having an offset of 2.5s and the upper bound
-    /// having an offset of 3.5s, to represent the error introduced by the round trip time.
+    /// For example, given a clock offset to a remote replica of 3s, a round trip time of 1s, and
+    /// a maximum tolerance between clocks of 100ms on either side, we might create two tuples, the
+    /// lower bound having an offset of 2.4s and the upper bound having an offset of 3.6s,
+    /// to represent the error introduced by the round trip time and by the clocks themselves.
     pub const Tuple = struct {
         source: u8,
         offset: i64,

--- a/src/marzullo.zig
+++ b/src/marzullo.zig
@@ -116,9 +116,9 @@ pub const Marzullo = struct {
             } else if (count == best and tuples[i + 1].bound == .upper) {
                 // This is a tie for best overlap. Both intervals have the same number of sources.
                 // We want to choose the smaller of the two intervals:
-                const alternative = tuples[i + 1].offset - tuples[i].offset;
+                const alternative = tuples[i + 1].offset - tuple.offset;
                 if (alternative < interval.upper_bound - interval.lower_bound) {
-                    interval.lower_bound = tuples[i].offset;
+                    interval.lower_bound = tuple.offset;
                     interval.upper_bound = tuples[i + 1].offset;
                 }
             }

--- a/src/time.zig
+++ b/src/time.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+pub const Time = struct {
+    const Self = @This();
+
+    /// Hardware and/or software bugs can mean that the monotonic clock may regress.
+    /// One example (of many): https://bugzilla.redhat.com/show_bug.cgi?id=448449
+    /// We crash the process for safety if this ever happens, to protect against infinite loops.
+    /// It's better to crash and come back with a valid monotonic clock than get stuck forever.
+    monotonic_guard: u64 = 0,
+
+    /// A timestamp to measure elapsed time, meaningful only on the same system, not across reboots.
+    /// Always use a monotonic timestamp if the goal is to measure elapsed time.
+    /// This clock is not affected by discontinuous jumps in the system time, for example if the
+    /// system administrator manually changes the clock.
+    pub fn monotonic(self: *Self) u64 {
+        // The true monotonic clock on Linux is not in fact CLOCK_MONOTONIC:
+        // CLOCK_MONOTONIC excludes elapsed time while the system is suspended (e.g. VM migration).
+        // CLOCK_BOOTTIME is the same as CLOCK_MONOTONIC but includes elapsed time during a suspend.
+        // For more detail and why CLOCK_MONOTONIC_RAW is even worse than CLOCK_MONOTONIC,
+        // see https://github.com/ziglang/zig/pull/933#discussion_r656021295.
+        var ts: std.os.timespec = undefined;
+        std.os.clock_gettime(std.os.CLOCK_BOOTTIME, &ts) catch unreachable;
+        const m = @intCast(u64, ts.tv_sec) * std.time.ns_per_s + @intCast(u64, ts.tv_nsec);
+        assert(m >= self.monotonic_guard);
+        self.monotonic_guard = m;
+        return m;
+    }
+
+    /// A timestamp to measure real (i.e. wall clock) time, meaningful across systems, and reboots.
+    /// This clock is affected by discontinuous jumps in the system time.
+    pub fn realtime(self: *Self) i64 {
+        var ts: std.os.timespec = undefined;
+        std.os.clock_gettime(std.os.CLOCK_REALTIME, &ts) catch unreachable;
+        return @as(i64, ts.tv_sec) * std.time.ns_per_s + ts.tv_nsec;
+    }
+
+    pub fn tick(self: *Self) void {}
+};
+
+pub const DeterministicTime = struct {
+    const Self = @This();
+
+    /// The duration of a single tick in nanoseconds.
+    resolution: u64,
+
+    /// The number of ticks elapsed since initialization.
+    ticks: u64 = 0,
+
+    /// The instant in time chosen as the origin of this time source.
+    epoch: i64 = 0,
+
+    pub fn monotonic(self: *Self) u64 {
+        return self.ticks * self.resolution;
+    }
+
+    pub fn realtime(self: *Self) i64 {
+        return self.epoch + @intCast(i64, self.monotonic());
+    }
+
+    pub fn tick(self: *Self) void {
+        self.ticks += 1;
+    }
+};

--- a/src/time.zig
+++ b/src/time.zig
@@ -21,9 +21,10 @@ pub const Time = struct {
         // For more detail and why CLOCK_MONOTONIC_RAW is even worse than CLOCK_MONOTONIC,
         // see https://github.com/ziglang/zig/pull/933#discussion_r656021295.
         var ts: std.os.timespec = undefined;
-        std.os.clock_gettime(std.os.CLOCK_BOOTTIME, &ts) catch unreachable;
+        std.os.clock_gettime(std.os.CLOCK_BOOTTIME, &ts) catch @panic("CLOCK_BOOTTIME required");
         const m = @intCast(u64, ts.tv_sec) * std.time.ns_per_s + @intCast(u64, ts.tv_nsec);
-        assert(m >= self.monotonic_guard);
+        // "Oops!...I Did It Again"
+        if (m < self.monotonic_guard) @panic("a hardware/kernel bug regressed the monotonic clock");
         self.monotonic_guard = m;
         return m;
     }

--- a/src/vr.zig
+++ b/src/vr.zig
@@ -8,6 +8,9 @@ const config = @import("config.zig");
 const Operation = @import("state_machine.zig").Operation;
 
 pub const Replica = @import("vr/replica.zig").Replica;
+pub const Clock = @import("vr/clock.zig").Clock;
+pub const DeterministicTime = @import("vr/clock.zig").DeterministicTime;
+pub const SystemTime = @import("vr/clock.zig").SystemTime;
 pub const Journal = @import("vr/journal.zig").Journal;
 
 // TODO Command for client to fetch its latest request number from the cluster.

--- a/src/vr/clock.zig
+++ b/src/vr/clock.zig
@@ -296,7 +296,7 @@ pub const Clock = struct {
             if (tolerance == 0) terminate = true;
             rounds += 1;
 
-            var interval = Marzullo.smallest_interval(self.window_tuples(tolerance));
+            const interval = Marzullo.smallest_interval(self.window_tuples(tolerance));
             const majority = interval.sources_true > @divTrunc(self.window.sources.len, 2);
             if (!majority) break;
 

--- a/src/vr/clock.zig
+++ b/src/vr/clock.zig
@@ -4,7 +4,6 @@ const log = std.log.scoped(.clock);
 
 const config = @import("../config.zig");
 
-const clock_offset_tolerance_min: u64 = config.clock_offset_tolerance_min_ms * std.time.ns_per_ms;
 const clock_offset_tolerance_max: u64 = config.clock_offset_tolerance_max_ms * std.time.ns_per_ms;
 const epoch_max: u64 = config.clock_epoch_max_ms * std.time.ns_per_ms;
 const window_min: u64 = config.clock_synchronization_window_min_ms * std.time.ns_per_ms;
@@ -24,6 +23,9 @@ const Epoch = struct {
     /// The best clock offset sample per remote clock source (with minimum one way delay) collected
     /// over the course of a window period of several seconds.
     sources: []?Sample,
+
+    /// The total number of samples learned while synchronizing this epoch.
+    samples: usize,
 
     /// The monotonic clock timestamp when this epoch began. We use this to measure elapsed time.
     monotonic: u64,
@@ -55,10 +57,19 @@ const Epoch = struct {
             .clock_offset = 0,
             .one_way_delay = 0,
         };
+        self.samples = 1;
         self.monotonic = clock.monotonic();
         self.realtime = clock.realtime();
         self.synchronized = null;
         self.learned = false;
+    }
+
+    fn sources_sampled(self: *Self) usize {
+        var count: usize = 0;
+        for (self.sources) |sampled| {
+            if (sampled != null) count += 1;
+        }
+        return count;
     }
 };
 
@@ -135,8 +146,7 @@ pub const Clock = struct {
         // This condition should never be true. Reject this as a bad sample:
         if (m0 >= m2) return;
 
-        // We may receive delayed packets after a reboot, in which case m0/m2 will also be invalid:
-        // TODO Add an identifier for this epoch to pings/pongs to bind them to the current window.
+        // We may receive delayed packets after a reboot, in which case m0/m2 may be invalid:
         if (m0 < self.window.monotonic) return;
         if (m2 < self.window.monotonic) return;
         const elapsed: u64 = m2 - self.window.monotonic;
@@ -146,25 +156,32 @@ pub const Clock = struct {
         const one_way_delay: u64 = round_trip_time / 2;
         const t2: i64 = self.window.realtime + @intCast(i64, elapsed);
         const clock_offset: i64 = t1 + @intCast(i64, one_way_delay) - t2;
+        const asymmetric_delay = self.estimate_asymmetric_delay(
+            replica,
+            one_way_delay,
+            clock_offset,
+        );
+        const clock_offset_corrected = clock_offset + asymmetric_delay;
 
-        log.debug("learn: replica={} m0={} t1={} m2={} t2={} one_way_delay={} clock_offset={}", .{
+        log.debug("learn: replica={} m0={} t1={} m2={} t2={} one_way_delay={} " ++
+            "asymmetric_delay={} clock_offset={}", .{
             replica,
             m0,
             t1,
             m2,
             t2,
             one_way_delay,
-            clock_offset,
+            asymmetric_delay,
+            clock_offset_corrected,
         });
-
-        // TODO Correct asymmetric error when we can see it's there.
-        // "A System for Clock Synchronization in an Internet of Things" Section 4.2
 
         // The less network delay, the more likely we have an accurante clock offset measurement:
         self.window.sources[replica] = minimum_one_way_delay(self.window.sources[replica], Sample{
-            .clock_offset = clock_offset,
+            .clock_offset = clock_offset_corrected,
             .one_way_delay = one_way_delay,
         });
+
+        self.window.samples += 1;
 
         // We decouple calls to `synchronize()` so that it's not triggered by these network events.
         // Otherwise, excessive duplicate network packets would burn the CPU.
@@ -207,9 +224,36 @@ pub const Clock = struct {
 
         // Expire the current epoch if successive windows failed to synchronize:
         // Gradual clock drift prevents us from using an epoch for more than a few tens of seconds.
-        if (self.epoch.synchronized != null and self.epoch.elapsed(self) >= epoch_max) {
+        if (self.epoch.elapsed(self) >= epoch_max) {
             log.alert("no agreement on cluster time (partitioned or too many clock faults)", .{});
             self.epoch.reset(self);
+        }
+    }
+
+    /// Estimates the asymmetric delay for a sample compared to the previous window, according to
+    /// Algorithm 1 from Section 4.2, "A System for Clock Synchronization in an Internet of Things".
+    fn estimate_asymmetric_delay(
+        self: *Self,
+        replica: u8,
+        one_way_delay: u64,
+        clock_offset: i64,
+    ) i64 {
+        const error_margin = 10 * std.time.ns_per_ms;
+
+        if (self.epoch.sources[replica]) |epoch| {
+            if (one_way_delay <= epoch.one_way_delay) {
+                return 0;
+            } else if (clock_offset > epoch.clock_offset + error_margin) {
+                // The asymmetric error is on the forward network path.
+                return 0 - @intCast(i64, one_way_delay - epoch.one_way_delay);
+            } else if (clock_offset < epoch.clock_offset - error_margin) {
+                // The asymmetric error is on the reverse network path.
+                return 0 + @intCast(i64, one_way_delay - epoch.one_way_delay);
+            } else {
+                return 0;
+            }
+        } else {
+            return 0;
         }
     }
 
@@ -221,8 +265,18 @@ pub const Clock = struct {
         if (elapsed < window_min) return;
         if (elapsed >= window_max) {
             // We took too long to synchronize the window, expire stale samples...
-            // TODO Count the samples in a window and show them here and elsewhere for confidence.
-            log.crit("expiring failed synchronization window", .{});
+            const sources_sampled = self.window.sources_sampled();
+            if (sources_sampled <= @divTrunc(self.window.sources.len, 2)) {
+                log.crit("synchronization window failed, partitioned (sources={} samples={})", .{
+                    sources_sampled,
+                    self.window.samples,
+                });
+            } else {
+                log.crit("synchronization window failed, no agreement (sources={} samples={})", .{
+                    sources_sampled,
+                    self.window.samples,
+                });
+            }
             self.window.reset(self);
             return;
         }
@@ -233,10 +287,12 @@ pub const Clock = struct {
 
         // Starting with the most clock offset tolerance, while we have a majority, find the best
         // smallest interval with the least clock offset tolerance, reducing tolerance at each step:
-        // We cap the number of rounds to avoid runaway loops.
         var tolerance: u64 = clock_offset_tolerance_max;
+        var terminate = false;
         var rounds: usize = 0;
-        while (tolerance >= clock_offset_tolerance_min and rounds < 64) : (tolerance /= 2) {
+        // Do at least one round if tolerance=0 and cap the number of rounds to avoid runaway loops.
+        while (!terminate and rounds < 64) : (tolerance /= 2) {
+            if (tolerance == 0) terminate = true;
             rounds += 1;
 
             var interval = Marzullo.smallest_interval(self.window_tuples(tolerance));
@@ -246,8 +302,6 @@ pub const Clock = struct {
             // The new interval may reduce the number of `sources_true` while also decreasing error.
             // In other words, provided we maintain a majority, we prefer tighter tolerance bounds.
             self.window.synchronized = interval;
-
-            if (tolerance == clock_offset_tolerance_min) break;
         }
 
         // Wait for more accurate samples or until we timeout the window for lack of majority:
@@ -281,13 +335,23 @@ pub const Clock = struct {
         if (system == cluster) {
             log.info("system time is within cluster time", .{});
         } else if (system < lower) {
-            log.err("system time is {} behind, clamping system time to cluster time", .{
-                fmtDurationSigned(lower - system),
-            });
+            const delta = lower - system;
+            if (delta < std.time.ns_per_ms) {
+                log.info("system time is {} behind", .{fmtDurationSigned(delta)});
+            } else {
+                log.err("system time is {} behind, clamping system time to cluster time", .{
+                    fmtDurationSigned(delta),
+                });
+            }
         } else {
-            log.err("system time is {} ahead, clamping system time to cluster time", .{
-                fmtDurationSigned(system - upper),
-            });
+            const delta = system - upper;
+            if (delta < std.time.ns_per_ms) {
+                log.info("system time is {} ahead", .{fmtDurationSigned(delta)});
+            } else {
+                log.err("system time is {} ahead, clamping system time to cluster time", .{
+                    fmtDurationSigned(delta),
+                });
+            }
         }
     }
 

--- a/src/vr/replica.zig
+++ b/src/vr/replica.zig
@@ -5,15 +5,14 @@ const log = std.log.scoped(.vr);
 
 const config = @import("../config.zig");
 
+const Time = @import("../time.zig").Time;
 const MessageBus = @import("../message_bus.zig").MessageBusReplica;
 const Message = @import("../message_bus.zig").Message;
-
 const StateMachine = @import("../state_machine.zig").StateMachine;
 
 const vr = @import("../vr.zig");
 const Header = vr.Header;
 const Clock = vr.Clock;
-const SystemTime = vr.SystemTime;
 const Journal = vr.Journal;
 const Timeout = vr.Timeout;
 const Command = vr.Command;
@@ -158,7 +157,7 @@ pub const Replica = struct {
         cluster: u128,
         replica_count: u16,
         replica: u16,
-        time: *SystemTime,
+        time: *Time,
         // TODO We should actually provide Storage here, a Replica will always use the same Journal:
         journal: *Journal,
         message_bus: *MessageBus,


### PR DESCRIPTION
Estimates accurate time with lower and upper bounds from a number of noisy time sources by calculating the smallest interval consistent with the largest number of sources, given the clock offsets and round trip times to these sources.