### PR TITLE
RingBuffer: Add iterator() and change peek() to return a pointer

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -214,10 +214,10 @@ const TimedQueue = struct {
         self.reset();
         log.debug("executing batches...", .{});
 
-        var batch: ?Batch = self.batches.peek();
+        var batch: ?*Batch = self.batches.peek();
         const now = std.time.milliTimestamp();
         self.start = now;
-        if (batch) |*starting_batch| {
+        if (batch) |starting_batch| {
             log.debug("sending first batch...", .{});
             self.batch_start = now;
             self.client.request(
@@ -264,8 +264,8 @@ const TimedQueue = struct {
             else => unreachable,
         }
 
-        var batch: ?Batch = self.batches.peek();
-        if (batch) |*next_batch| {
+        var batch: ?*Batch = self.batches.peek();
+        if (batch) |next_batch| {
             self.batch_start = std.time.milliTimestamp();
             self.client.request(
                 @intCast(u128, @ptrToInt(self)),

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -214,10 +214,9 @@ const TimedQueue = struct {
         self.reset();
         log.debug("executing batches...", .{});
 
-        const batch: ?*Batch = self.batches.peek();
         const now = std.time.milliTimestamp();
         self.start = now;
-        if (batch) |starting_batch| {
+        if (self.batches.peek_ptr()) |starting_batch| {
             log.debug("sending first batch...", .{});
             self.batch_start = now;
             self.client.request(
@@ -264,8 +263,7 @@ const TimedQueue = struct {
             else => unreachable,
         }
 
-        var batch: ?*Batch = self.batches.peek();
-        if (batch) |next_batch| {
+        if (self.batches.peek_ptr()) |next_batch| {
             self.batch_start = std.time.milliTimestamp();
             self.client.request(
                 @intCast(u128, @ptrToInt(self)),

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -214,7 +214,7 @@ const TimedQueue = struct {
         self.reset();
         log.debug("executing batches...", .{});
 
-        var batch: ?*Batch = self.batches.peek();
+        const batch: ?*Batch = self.batches.peek();
         const now = std.time.milliTimestamp();
         self.start = now;
         if (batch) |starting_batch| {

--- a/src/client.zig
+++ b/src/client.zig
@@ -181,7 +181,7 @@ pub const Client = struct {
     }
 
     fn on_request_timeout(self: *Client) void {
-        const current_request = self.request_queue.peek() orelse return;
+        const current_request = (self.request_queue.peek() orelse return).*;
 
         log.debug("Retrying timed out request {o}.", .{current_request.message.header});
         self.request_timeout.stop();
@@ -213,7 +213,7 @@ pub const Client = struct {
         assert(reply.header.valid_checksum());
         assert(reply.header.valid_checksum_body(reply.body()));
 
-        const queued_request = self.request_queue.peek().?;
+        const queued_request = self.request_queue.peek().?.*;
         if (reply.header.client != self.id or reply.header.cluster != self.cluster) {
             log.debug("{} on_reply: Dropping unsolicited message.", .{self.id});
             return;
@@ -239,7 +239,7 @@ pub const Client = struct {
         self.message_bus.unref(queued_request.message);
 
         if (self.request_queue.peek()) |next_request| {
-            self.send_request(next_request.message);
+            self.send_request(next_request.*.message);
         }
     }
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -181,7 +181,7 @@ pub const Client = struct {
     }
 
     fn on_request_timeout(self: *Client) void {
-        const current_request = (self.request_queue.peek() orelse return).*;
+        const current_request = self.request_queue.peek_ptr() orelse return;
 
         log.debug("Retrying timed out request {o}.", .{current_request.message.header});
         self.request_timeout.stop();
@@ -213,11 +213,12 @@ pub const Client = struct {
         assert(reply.header.valid_checksum());
         assert(reply.header.valid_checksum_body(reply.body()));
 
-        const queued_request = self.request_queue.peek().?.*;
         if (reply.header.client != self.id or reply.header.cluster != self.cluster) {
             log.debug("{} on_reply: Dropping unsolicited message.", .{self.id});
             return;
         }
+
+        const queued_request = self.request_queue.peek_ptr().?;
 
         if (reply.header.request < queued_request.message.header.request) {
             log.debug(
@@ -238,8 +239,8 @@ pub const Client = struct {
         _ = self.request_queue.pop().?;
         self.message_bus.unref(queued_request.message);
 
-        if (self.request_queue.peek()) |next_request| {
-            self.send_request(next_request.*.message);
+        if (self.request_queue.peek_ptr()) |next_request| {
+            self.send_request(next_request.message);
         }
     }
 

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -996,7 +996,7 @@ fn MessageBusImpl(comptime process_type: ProcessType) type {
                 assert(self.peer == .client or self.peer == .replica);
                 assert(self.state == .connected);
                 assert(self.fd != -1);
-                const message = (self.send_queue.peek() orelse return).*;
+                const message = self.send_queue.peek() orelse return;
                 assert(!self.send_submitted);
                 self.send_submitted = true;
                 bus.io.send(
@@ -1026,9 +1026,9 @@ fn MessageBusImpl(comptime process_type: ProcessType) type {
                     self.terminate(bus, .shutdown);
                     return;
                 };
-                assert(self.send_progress <= self.send_queue.peek().?.*.header.size);
+                assert(self.send_progress <= self.send_queue.peek_ptr().?.*.header.size);
                 // If the message has been fully sent, move on to the next one.
-                if (self.send_progress == self.send_queue.peek().?.*.header.size) {
+                if (self.send_progress == self.send_queue.peek_ptr().?.*.header.size) {
                     self.send_progress = 0;
                     const message = self.send_queue.pop().?;
                     bus.unref(message);

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -996,7 +996,7 @@ fn MessageBusImpl(comptime process_type: ProcessType) type {
                 assert(self.peer == .client or self.peer == .replica);
                 assert(self.state == .connected);
                 assert(self.fd != -1);
-                const message = self.send_queue.peek() orelse return;
+                const message = (self.send_queue.peek() orelse return).*;
                 assert(!self.send_submitted);
                 self.send_submitted = true;
                 bus.io.send(
@@ -1026,9 +1026,9 @@ fn MessageBusImpl(comptime process_type: ProcessType) type {
                     self.terminate(bus, .shutdown);
                     return;
                 };
-                assert(self.send_progress <= self.send_queue.peek().?.header.size);
+                assert(self.send_progress <= self.send_queue.peek().?.*.header.size);
                 // If the message has been fully sent, move on to the next one.
-                if (self.send_progress == self.send_queue.peek().?.header.size) {
+                if (self.send_progress == self.send_queue.peek().?.*.header.size) {
                     self.send_progress = 0;
                     const message = self.send_queue.pop().?;
                     bus.unref(message);


### PR DESCRIPTION
We can now iterate ring buffer items as pointers, and with `peek()` now returning a pointer we can also mutate the peeked item.

The reason for adding the iterator is for use within `Replica`, to iterate a ring buffer of inflight prepares.