### PR TITLE
Clock: unit and basic fuzz tests

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -28,7 +28,10 @@ trap onerror EXIT
 for I in 0
 do
     echo "Initializing replica $I..."
-    rm "./cluster_0000000001_replica_00${I}.tigerbeetle"
+    FILE="./cluster_0000000001_replica_00${I}.tigerbeetle"
+    if [ -f $FILE ]; then
+        rm $FILE
+    fi
     ./tigerbeetle init --directory=. --cluster=1 --replica=$I > benchmark.log 2>&1
 done
 

--- a/src/mock_network.zig
+++ b/src/mock_network.zig
@@ -1,0 +1,229 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const log = std.log.scoped(.mock_network);
+
+pub const MockNetworkOptions = struct {
+    /// Mean for the exponential distribution used to calculate forward delay.
+    forward_delay_mean: u64,
+
+    /// Mean for the exponential distribution used to calculate reverse delay.
+    reverse_delay_mean: u64,
+    min_forward_delay: u64,
+    min_reverse_delay: u64,
+    packet_loss_probability: u8,
+    packet_replay_probability: u8,
+    prng_seed: u64,
+    node_count: u8,
+
+    /// The maximum number of in-flight packets a path can have before packets are randomly dropped.
+    path_maximum_capacity: u8,
+
+    /// Mean for the exponential distribution used to calculate how long a path is clogged for.
+    path_clog_duration_mean: u64,
+    path_clog_probability: u8,
+};
+
+/// A fully connected network of nodes used for testing. Simulates the fault model:
+/// Packets may be dropped.
+/// Packets may be delayed.
+/// Packets may be replayed.
+pub const PacketStatistics = enum(u8) {
+    dropped_due_to_congestion,
+    dropped,
+    forward_replay,
+    reverse_replay,
+};
+pub fn MockNetwork(comptime Packet: type) type {
+    return struct {
+        const Self = @This();
+        const Direction = enum(u8) {
+            forward,
+            reverse,
+        };
+        const Data = struct {
+            expiry: u64,
+            callback: fn (
+                packet: Packet,
+                to: u8,
+                from: u8,
+            ) void,
+            packet: Packet,
+            direction: Direction,
+        };
+
+        /// A send and receive path between each node in the network. We use the `path` function to
+        /// index it.
+        paths: []std.PriorityQueue(Data),
+
+        /// We can arbitrary clog a path until a tick.
+        path_clogged_till: []u64,
+        ticks: u64 = 0,
+        options: MockNetworkOptions,
+        prng: std.rand.DefaultPrng,
+        stats: [@typeInfo(PacketStatistics).Enum.fields.len]u32 = [_]u32{0} **
+            @typeInfo(PacketStatistics).Enum.fields.len,
+
+        pub fn init(allocator: *std.mem.Allocator, options: MockNetworkOptions) !Self {
+            var self = Self{
+                .paths = try allocator.alloc(
+                    std.PriorityQueue(Data),
+                    options.node_count * options.node_count,
+                ),
+                .path_clogged_till = try allocator.alloc(
+                    u64,
+                    options.node_count * options.node_count,
+                ),
+                .options = options,
+                .prng = std.rand.DefaultPrng.init(options.prng_seed),
+            };
+
+            for (self.paths) |*queue| {
+                queue.* = std.PriorityQueue(Data).init(allocator, Self.order_packets);
+                try queue.ensureCapacity(options.path_maximum_capacity);
+            }
+
+            for (self.path_clogged_till) |*clogged_till| {
+                clogged_till.* = 0;
+            }
+
+            return self;
+        }
+
+        fn order_packets(a: Data, b: Data) std.math.Order {
+            return std.math.order(a.expiry, b.expiry);
+        }
+
+        fn should_drop(self: *Self) bool {
+            return self.prng.random.uintAtMost(u8, 100) < self.options.packet_loss_probability;
+        }
+
+        fn path_index(self: *Self, from: u8, to: u8) usize {
+            assert(from < self.options.node_count and to < self.options.node_count);
+
+            return from * self.options.node_count + to;
+        }
+
+        fn path(self: *Self, from: u8, to: u8) *std.PriorityQueue(Data) {
+            var index = self.path_index(from, to);
+            return &self.paths[from * self.options.node_count + to];
+        }
+
+        fn is_clogged(self: *Self, from: u8, to: u8) bool {
+            return self.path_clogged_till[self.path_index(from, to)] > self.ticks;
+        }
+
+        fn should_clog(self: *Self, from: u8, to: u8) bool {
+            return self.prng.random.uintAtMost(u8, 100) < self.options.path_clog_probability;
+        }
+
+        fn clog_for(self: *Self, from: u8, to: u8, ticks: u64) void {
+            const clog_expiry = &self.path_clogged_till[self.path_index(from, to)];
+            clog_expiry.* = self.ticks + ticks;
+            log.debug("Path from={} to={} clogged until tick={}.", .{ from, to, clog_expiry.* });
+        }
+
+        fn should_replay(self: *Self) bool {
+            return self.prng.random.uintAtMost(u8, 100) < self.options.packet_replay_probability;
+        }
+
+        /// We assume the one way delay will follow an exponential distrbution with there being a
+        /// minimum delay.
+        fn one_way_delay(self: *Self, direction: Direction) u64 {
+            switch (direction) {
+                .forward => {
+                    var delay = self.options.forward_delay_mean *
+                        @floatToInt(u64, self.prng.random.floatExp(f64));
+
+                    return if (self.options.min_forward_delay < delay) delay else self.options.min_forward_delay;
+                },
+                .reverse => {
+                    var delay = self.options.reverse_delay_mean *
+                        @floatToInt(u64, self.prng.random.floatExp(f64));
+
+                    return if (self.options.min_reverse_delay < delay) delay else self.options.min_reverse_delay;
+                },
+            }
+        }
+
+        pub fn tick(self: *Self) void {
+            self.ticks += 1;
+
+            var from: u8 = 0;
+            while (from < self.options.node_count) : (from += 1) {
+                var to: u8 = 0;
+                while (to < self.options.node_count) : (to += 1) {
+                    if (self.is_clogged(from, to)) continue;
+
+                    const queue = self.path(from, to);
+                    while (queue.peek()) |data| {
+                        if (data.expiry > self.ticks) break;
+                        _ = queue.remove();
+
+                        if (self.should_drop()) {
+                            self.stats[@enumToInt(PacketStatistics.dropped)] += 1;
+                            log.debug("dropped packet from={} to={}.", .{ from, to });
+                            continue;
+                        }
+
+                        if (self.should_replay()) {
+                            self.submit_packet(
+                                data.packet,
+                                data.callback,
+                                to,
+                                from,
+                                data.direction,
+                            );
+
+                            log.debug("replayed packet from={} to={}", .{ from, to });
+                            switch (data.direction) {
+                                .forward => self.stats[@enumToInt(PacketStatistics.forward_replay)] += 1,
+                                .reverse => self.stats[@enumToInt(PacketStatistics.reverse_replay)] += 1,
+                            }
+                        }
+
+                        data.callback(data.packet, to, from);
+                    }
+
+                    if (self.should_clog(from, to)) {
+                        var ticks = self.options.path_clog_duration_mean *
+                            @floatToInt(u64, self.prng.random.floatExp(f64));
+
+                        self.clog_for(from, to, ticks);
+                    }
+                }
+            }
+        }
+
+        pub fn submit_packet(
+            self: *Self,
+            packet: Packet,
+            callback: fn (packet: Packet, to: u8, from: u8) void,
+            to: u8,
+            from: u8,
+            direction: Direction,
+        ) void {
+            const queue = self.path(from, to);
+            // We simulate network congestion by dropping a random packet in the queue if
+            // its capacity is exceeded.
+            var queue_length = queue.count();
+            if (queue_length + 1 > queue.capacity()) {
+                var index_to_drop = self.prng.random.uintLessThanBiased(u64, queue_length);
+                _ = queue.removeIndex(index_to_drop);
+                self.stats[@enumToInt(PacketStatistics.dropped_due_to_congestion)] += 1;
+
+                log.debug(
+                    "path from={} to={} reached capacity. Dropped packet at index={}.",
+                    .{ from, to, index_to_drop },
+                );
+                return;
+            }
+
+            queue.add(.{
+                .expiry = self.ticks + self.one_way_delay(direction),
+                .packet = packet,
+                .callback = callback,
+                .direction = direction,
+            }) catch unreachable;
+        }
+    };
+}

--- a/src/network_simulator.zig
+++ b/src/network_simulator.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.mock_network);
 
-pub const MockNetworkOptions = struct {
+pub const NetworkSimulatorOptions = struct {
     /// Mean for the exponential distribution used to calculate forward delay.
     forward_delay_mean: u64,
 
@@ -33,7 +33,7 @@ pub const PacketStatistics = enum(u8) {
     forward_replay,
     reverse_replay,
 };
-pub fn MockNetwork(comptime Packet: type) type {
+pub fn NetworkSimulator(comptime Packet: type) type {
     return struct {
         const Self = @This();
         const Direction = enum(u8) {
@@ -58,12 +58,12 @@ pub fn MockNetwork(comptime Packet: type) type {
         /// We can arbitrary clog a path until a tick.
         path_clogged_till: []u64,
         ticks: u64 = 0,
-        options: MockNetworkOptions,
+        options: NetworkSimulatorOptions,
         prng: std.rand.DefaultPrng,
         stats: [@typeInfo(PacketStatistics).Enum.fields.len]u32 = [_]u32{0} **
             @typeInfo(PacketStatistics).Enum.fields.len,
 
-        pub fn init(allocator: *std.mem.Allocator, options: MockNetworkOptions) !Self {
+        pub fn init(allocator: *std.mem.Allocator, options: NetworkSimulatorOptions) !Self {
             var self = Self{
                 .paths = try allocator.alloc(
                     std.PriorityQueue(Data),

--- a/src/time.zig
+++ b/src/time.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
+const config = @import("./config.zig");
 
 pub const Time = struct {
     const Self = @This();
@@ -40,11 +41,24 @@ pub const Time = struct {
     pub fn tick(self: *Self) void {}
 };
 
+pub const OffsetType = enum { linear, periodic, step };
 pub const DeterministicTime = struct {
     const Self = @This();
 
     /// The duration of a single tick in nanoseconds.
     resolution: u64,
+
+    offset_type: OffsetType,
+
+    /// Co-efficients to scale the offset according to the `offset_type`.
+    /// Linear offset is described as A * x + B: A is the drift per tick and B the initial offset.
+    /// Periodic is described as A * sin(x * pi / B): A controls the amplitude and B the period in
+    /// terms of ticks.
+    /// Step function represents a discontinuous jump in the wall-clock time. B is the period in
+    /// which the jumps occur. A is the amplitude of the step.
+    /// Combination
+    offset_coefficient_A: i64,
+    offset_coefficient_B: u64,
 
     /// The number of ticks elapsed since initialization.
     ticks: u64 = 0,
@@ -57,7 +71,25 @@ pub const DeterministicTime = struct {
     }
 
     pub fn realtime(self: *Self) i64 {
-        return self.epoch + @intCast(i64, self.monotonic());
+        return self.epoch + @intCast(i64, self.monotonic()) - self.offset(self.ticks);
+    }
+
+    pub fn offset(self: *Self, ticks: u64) i64 {
+        switch (self.offset_type) {
+            .linear => {
+                const drift_per_tick = self.offset_coefficient_A;
+                return @intCast(i64, ticks) * drift_per_tick + @intCast(i64, self.offset_coefficient_B);
+            },
+            .periodic => {
+                const unscaled = std.math.sin(@intToFloat(f64, ticks) * 2 * std.math.pi /
+                    @intToFloat(f64, self.offset_coefficient_B));
+                const scaled = @intToFloat(f64, self.offset_coefficient_A) * unscaled;
+                return @floatToInt(i64, std.math.floor(scaled));
+            },
+            .step => {
+                return if (ticks > self.offset_coefficient_B) self.offset_coefficient_A else 0;
+            },
+        }
     }
 
     pub fn tick(self: *Self) void {


### PR DESCRIPTION
This updates ideal Deterministic Time to be used in unit and fuzz
tests.

A Mock Network has been introduced that simulates a network where
packets may be delayed, dropped or replayed. Network metrics such as
one-way-delay, probability of packet loss or replays have been
parameterized so that differing network performance may be modeled.
This will be used in future fuzz testing work.

A Clock Simulator has been introduced to fuzz test the clock
implementation. It uses the Mock Network to send packets between the
clocks.