### PR TITLE
Add GitHub Action to build Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Docker CI
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - 'main'
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: ./scripts/install_zig.sh
+      - run: zig/zig build test
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/main' }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
-FROM ubuntu:20.10
-WORKDIR /tmp/zig
+FROM ubuntu:20.10 as build
 
 RUN  apt-get update \
   && apt-get install -y wget xz-utils
-RUN wget -q https://ziglang.org/builds/zig-linux-x86_64-0.6.0+fd4783906.tar.xz && \
-        tar -xf zig-linux-x86_64-0.6.0+fd4783906.tar.xz && \
-        mv "zig-linux-x86_64-0.6.0+fd4783906" /usr/local/lib/zig && \
-        ln -s /usr/local/lib/zig/zig /usr/local/bin/zig && \
-        rm zig-linux-x86_64-0.6.0+fd4783906.tar.xz
 
-WORKDIR /opt/alpha-beetle
+WORKDIR /opt/beta-beetle
 
-COPY ./io_uring.zig .
-COPY ./server.zig .
+COPY src ./src
+COPY scripts ./scripts
+COPY build.zig ./build.zig
 
-RUN zig build-exe server.zig
+ENV PATH="${PATH}:/opt/beta-beetle/zig"
+RUN ./scripts/install.sh
 
-CMD ["./server"]
+FROM ubuntu:20.10
+WORKDIR /opt/beta-beetle
+
+COPY --from=build /opt/beta-beetle/tigerbeetle ./tigerbeetle
+
+ENTRYPOINT ["./tigerbeetle"]


### PR DESCRIPTION
Pushing to GitHub will publish the following Docker images to ghcr.io:

- branch --> `ghcr.io/coilhq/tigerbeetle:<branch>`
- tag --> `ghcr.io/coilhq/tigerbeetle:<tag>`
- `main` --> `ghcr.io/coilhq/tigerbeetle:latest`

You can see images created in my fork for reference, which worked without needing to change any repo settings:
https://github.com/wilsonianb/tigerbeetle/pkgs/container/tigerbeetle

I did get one build error when I pushed a tag of a commit that wasn't in any branches.
It succeeded when I re-ran the workflow after including the commit in `main`.