### PR TITLE
Add Windows 10 cmd Support for Simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode
 demos/bitcast/bench-decode
 demos/bitcast/decode
 demos/bitcast/transfers
@@ -11,7 +10,3 @@ cluster_*_replica_*.tigerbeetle
 zig/
 zig-cache/
 zig-out/
-
-# Project Files
-.idea
-*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,14 @@ demos/bitcast/decode
 demos/bitcast/transfers
 dist/
 journal
-main
 simulator
+main
 tigerbeetle
 cluster_*_replica_*.tigerbeetle
 zig/
 zig-cache/
 zig-out/
+
+# Project Files
+.idea
+*.iml

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -202,10 +202,8 @@ fn chance(random: *std.rand.Random, p: u8) bool {
 
 /// Returns the next argument for the simulator or null (if none available)
 fn args_next(args: *std.process.ArgIterator, allocator: *std.mem.Allocator) ?[:0]const u8 {
-    return if (args.next(allocator)) |err_or_bytes|
-        err_or_bytes catch @panic("Unable to extract next value from args")
-    else
-        null;
+    const err_or_bytes = args.next(allocator) orelse return null;
+    return err_or_bytes catch @panic("Unable to extract next value from args");
 }
 
 fn on_change_replica(replica: *Replica) void {

--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -34,12 +34,9 @@ pub fn main() !void {
 
     const seed_random = std.crypto.random.int(u64);
     const seed = seed_from_arg: {
-        const arg_two = args_next(&args, allocator);
-        if (arg_two == null) break :seed_from_arg seed_random;
-
-        const parsed_arg_seed = parse_seed(arg_two.?);
-        defer allocator.free(arg_two.?);
-        break :seed_from_arg parsed_arg_seed;
+        const arg_two = args_next(&args, allocator) orelse break :seed_from_arg seed_random;
+        defer allocator.free(arg_two);
+        break :seed_from_arg parse_seed(arg_two);
     };
 
     if (std.builtin.mode == .ReleaseFast or std.builtin.mode == .ReleaseSmall) {


### PR DESCRIPTION
# Why
Windows 10 simulator is failing due to `nextPoxis` (only UX support).
The `nextPoxis` needs to be replaced by `process.next()` instead.

# Testing

### No Arg
![image](https://user-images.githubusercontent.com/1992108/133405562-defe7b0d-dc55-4a73-a9ff-eb65faddfbeb.png)

### Arg
![image](https://user-images.githubusercontent.com/1992108/133405276-c19aaba1-707b-4959-b732-0c5885adafec.png)
