### PR TITLE
Fix for darwin to pass zig build test

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -1216,7 +1216,7 @@ test "accept/connect/send/receive" {
                 completion,
                 self.client,
                 &self.send_buf,
-                os.MSG_NOSIGNAL,
+                if (std.Target.current.os.tag == .linux) os.MSG_NOSIGNAL else 0,
             );
         }
 
@@ -1241,7 +1241,7 @@ test "accept/connect/send/receive" {
                 completion,
                 self.accepted_sock,
                 &self.recv_buf,
-                os.MSG_NOSIGNAL,
+                if (std.Target.current.os.tag == .linux) os.MSG_NOSIGNAL else 0,
             );
         }
 

--- a/src/io_darwin.zig
+++ b/src/io_darwin.zig
@@ -405,6 +405,7 @@ pub const IO = struct {
         InputOutput,
         NoSpaceLeft,
         ReadOnlyFileSystem,
+        AccessDenied,
     } || os.UnexpectedError;
 
     pub fn fsync(
@@ -455,6 +456,8 @@ pub const IO = struct {
         NoSpaceLeft,
         NotDir,
         FileLocksNotSupported,
+        BadPathName,
+        InvalidUtf8,
         WouldBlock,
     } || os.UnexpectedError;
 


### PR DESCRIPTION
First of all, thanks for a great library!
I'm learning a lot from the [Design Document](https://github.com/coilhq/tigerbeetle/blob/main/docs/DESIGN.md) and [Proposal: Event loop redesign · Issue #8224 · ziglang/zig](https://github.com/ziglang/zig/issues/8224).

This pull request fix errors I got when I ran `zig build test` on darwin.
I confirmed the tests pass on my Mac mini (M1, 2020) and my old Intel MacBook Pro.
