### PR TITLE
Fix FIFO assert for kevent Completions

### DIFF
--- a/src/io_darwin.zig
+++ b/src/io_darwin.zig
@@ -105,6 +105,7 @@ pub const IO = struct {
 
             for (events[0..new_events]) |event| {
                 const completion = @intToPtr(*Completion, event.udata);
+                completion.next = null;
                 self.completed.push(completion);
             }
         }


### PR DESCRIPTION
When generating kevents to register, we iterate through the `io_pending` FIFO and only mark the Completions as dequeued after a successful call to `os.kevent`. This "marking/dequeue" is done by setting the io_pending `.in` and `.out` fields directly to avoid re-traversing again with `.pop()` which ends up not nulling out the `.next` links. Once the Completion is reported from kevent(), it still has its `.next` field set and trips an assert when we try to push it to the `completed` FIFO.  

There's multiple ways to address this but nulling the `.next` link out ourselves seems like the simplest one.