### PR TITLE
add PoolType data structure

### DIFF
--- a/src/pool_type.zig
+++ b/src/pool_type.zig
@@ -1,0 +1,162 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+pub fn find_first_unset(self: std.DynamicBitSetUnmanaged) ?u64 {
+    var offset: u64 = 0;
+    var mask = self.masks;
+    while (offset < self.bit_length) {
+        if (~mask[0] != 0) break;
+        mask += 1;
+        offset += @bitSizeOf(std.DynamicBitSetUnmanaged.MaskInt);
+    } else return null;
+    const first_unset = offset + @ctz(~mask[0]);
+    return if (first_unset < self.bit_length) first_unset else null;
+}
+
+pub fn PoolType(comptime T: type) type {
+    return struct {
+        const Pool = @This();
+
+        items: []T,
+        busy: std.DynamicBitSetUnmanaged,
+
+        pub fn init(gpa: std.mem.Allocator, capacity: u64) !Pool {
+            const items = try gpa.alloc(T, capacity);
+            errdefer gpa.free(items);
+            const busy = try std.DynamicBitSetUnmanaged.initEmpty(gpa, capacity);
+            errdefer busy.deinit(gpa);
+            return Pool{ .items = items, .busy = busy };
+        }
+
+        pub fn deinit(self: *Pool, gpa: std.mem.Allocator) void {
+            self.busy.deinit(gpa);
+            gpa.free(self.items);
+        }
+
+        pub fn acquire(self: *Pool) ?*T {
+            const i = find_first_unset(self.busy) orelse return null;
+            self.busy.set(i);
+            return &self.items[i];
+        }
+
+        pub fn release(self: *Pool, item: *T) void {
+            const i = self.index(item);
+            assert(self.busy.isSet(i));
+            self.busy.unset(i);
+        }
+
+        pub fn index(self: *Pool, item: *T) u64 {
+            const i = @divExact(
+                (@intFromPtr(item) - @intFromPtr(self.items.ptr)),
+                @sizeOf(T),
+            );
+            assert(i < self.items.len);
+            return i;
+        }
+
+        /// Returns the count of elements available.
+        pub fn available(self: *const Pool) u64 {
+            return self.busy.capacity() - self.busy.count();
+        }
+
+        pub inline fn total(self: *const Pool) u64 {
+            return self.items.len;
+        }
+
+        /// Returns the count of elements in use.
+        pub fn in_use(self: *const Pool) u64 {
+            return self.busy.count();
+        }
+
+        pub const Iterator = struct {
+            pool: *Pool,
+            bitset_iterator: std.DynamicBitSetUnmanaged.Iterator(.{}),
+
+            pub fn next(iterator: *@This()) ?*T {
+                const i = iterator.bitset_iterator.next() orelse return null;
+                return &iterator.pool.items[i];
+            }
+        };
+
+        pub fn iterate(self: *Pool) Iterator {
+            return .{
+                .pool = self,
+                .bitset_iterator = self.busy.iterator(.{}),
+            };
+        }
+    };
+}
+
+test find_first_unset {
+    const alloc = std.testing.allocator;
+    const capacity = 4;
+    var bitset = try std.DynamicBitSetUnmanaged.initEmpty(alloc, capacity);
+    defer bitset.deinit(alloc);
+    for (0..capacity) |index| {
+        bitset.set(index);
+        if (index + 1 == capacity) {
+            try std.testing.expectEqual(null, find_first_unset(bitset));
+        } else {
+            try std.testing.expectEqual(index + 1, find_first_unset(bitset));
+        }
+    }
+    try std.testing.expectEqual(capacity, bitset.count());
+    for (1..capacity + 1) |index| {
+        const reverse_index = capacity - index;
+        bitset.unset(reverse_index);
+        try std.testing.expectEqual(find_first_unset(bitset), reverse_index);
+    }
+    try std.testing.expectEqual(0, bitset.count());
+}
+
+test PoolType {
+    const testing = std.testing;
+    var pool = try PoolType(u32).init(testing.allocator, 4);
+    defer pool.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u64, 4), pool.available());
+    try testing.expectEqual(@as(u64, 0), pool.in_use());
+
+    var one = pool.acquire().?;
+
+    try testing.expectEqual(@as(u64, 3), pool.available());
+    try testing.expectEqual(@as(u64, 1), pool.in_use());
+
+    var two = pool.acquire().?;
+    var three = pool.acquire().?;
+
+    try testing.expectEqual(@as(u64, 1), pool.available());
+    try testing.expectEqual(@as(u64, 3), pool.in_use());
+
+    var four = pool.acquire().?;
+    try testing.expectEqual(@as(?*u32, null), pool.acquire());
+
+    try testing.expectEqual(@as(u64, 0), pool.available());
+    try testing.expectEqual(@as(u64, 4), pool.in_use());
+
+    pool.release(two);
+
+    try testing.expectEqual(@as(u64, 1), pool.available());
+    try testing.expectEqual(@as(u64, 3), pool.in_use());
+
+    // there is only one slot free, so we will get the same pointer back.
+    try testing.expectEqual(@as(?*u32, two), pool.acquire());
+
+    pool.release(four);
+    pool.release(two);
+    pool.release(one);
+    pool.release(three);
+
+    try testing.expectEqual(@as(u64, 4), pool.available());
+    try testing.expectEqual(@as(u64, 0), pool.in_use());
+
+    one = pool.acquire().?;
+    two = pool.acquire().?;
+    three = pool.acquire().?;
+    four = pool.acquire().?;
+    try testing.expectEqual(@as(?*u32, null), pool.acquire());
+    pool.release(one);
+    pool.release(two);
+    pool.release(three);
+    pool.release(four);
+}

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1148,6 +1148,85 @@ pub fn term_from_status(status: u32) std.process.Child.Term {
         Term{ .Unknown = status };
 }
 
+/// Returns the index of the first set/unset bit (relative to the start of the bitset) within
+/// the range bit_min…bit_max (inclusive…exclusive).
+pub fn find_bit(
+    bit_set: std.DynamicBitSetUnmanaged,
+    bit_min: usize,
+    bit_max: usize,
+    comptime bit_kind: std.bit_set.IteratorOptions.Type,
+) ?usize {
+    const MaskInt = std.DynamicBitSetUnmanaged.MaskInt;
+    assert(bit_max >= bit_min);
+    assert(bit_max <= bit_set.bit_length);
+
+    const word_start = @divFloor(bit_min, @bitSizeOf(MaskInt)); // Inclusive.
+    const word_offset = @mod(bit_min, @bitSizeOf(MaskInt));
+    const word_end = div_ceil(bit_max, @bitSizeOf(MaskInt)); // Exclusive.
+    const words_total = div_ceil(bit_set.bit_length, @bitSizeOf(MaskInt));
+    if (word_end == word_start) return null;
+    assert(word_end > word_start);
+
+    // Only iterate over the subset of bits that were requested.
+    var iterator = bit_set.iterator(.{ .kind = bit_kind });
+    iterator.words_remain = bit_set.masks[word_start + 1 .. word_end];
+
+    const mask = ~@as(MaskInt, 0);
+    var word = bit_set.masks[word_start];
+    if (bit_kind == .unset) word = ~word;
+    iterator.bits_remain = word & std.math.shl(MaskInt, mask, word_offset);
+
+    if (word_end != words_total) iterator.last_word_mask = mask;
+
+    const b = bit_min - word_offset + (iterator.next() orelse return null);
+    return if (b < bit_max) b else null;
+}
+
+test "find_bit" {
+    var prng = PRNG.from_seed_testing();
+
+    const gpa = std.testing.allocator;
+    for (1..(@bitSizeOf(std.DynamicBitSetUnmanaged.MaskInt) * 4) + 1) |bit_length| {
+        var bit_set = try std.DynamicBitSetUnmanaged.initEmpty(gpa, bit_length);
+        defer bit_set.deinit(gpa);
+
+        const p = prng.int_inclusive(usize, 100);
+
+        for (0..bit_length) |b| bit_set.setValue(b, p < prng.int_inclusive(usize, 100));
+
+        for (0..20) |_| try test_find_bit(&prng, bit_set, .set);
+        for (20..40) |_| try test_find_bit(&prng, bit_set, .unset);
+    }
+}
+
+fn test_find_bit(
+    prng: *PRNG,
+    bit_set: std.DynamicBitSetUnmanaged,
+    comptime bit_kind: std.bit_set.IteratorOptions.Type,
+) !void {
+    const bit_min = prng.int_inclusive(usize, bit_set.bit_length - 1);
+    const bit_max = prng.range_inclusive(usize, bit_min, bit_set.bit_length);
+    assert(bit_max >= bit_min);
+    assert(bit_max <= bit_set.bit_length);
+
+    const bit_actual = find_bit(bit_set, bit_min, bit_max, bit_kind);
+    if (bit_actual) |bit| {
+        assert(bit_set.isSet(bit) == (bit_kind == .set));
+        assert(bit >= bit_min);
+        assert(bit < bit_max);
+    }
+
+    var iterator = bit_set.iterator(.{ .kind = bit_kind });
+    while (iterator.next()) |bit| {
+        if (bit_min <= bit and bit < bit_max) {
+            try std.testing.expectEqual(bit_actual, bit);
+            break;
+        }
+    } else {
+        try std.testing.expectEqual(bit_actual, null);
+    }
+}
+
 comptime {
     _ = @import("aegis.zig");
     _ = @import("bit_set.zig");

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -32,6 +32,7 @@ comptime {
     _ = @import("lsm/zig_zag_merge.zig");
     _ = @import("message_buffer.zig");
     _ = @import("multiversion.zig");
+    _ = @import("pool_type.zig");
     _ = @import("queue.zig");
     _ = @import("repl/completion.zig");
     _ = @import("repl/parser.zig");


### PR DESCRIPTION
Introduce `PoolType`, a general-purpose pool that complements the existing `IOPSType`. IT uses heap-backed items, which are `not` reset upon `release`.

This simplifies replicas `grid_repair_tables` and `grid_repair_writes` by not requiring an extra array for storing items that must not be reset.