### PR TITLE
release: bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Subscribe to the [tracking issue #2231](https://github.com/tigerbeetle/tigerbeetle/issues/2231)
 to receive notifications about breaking changes!
 
-## TigerBeetle 0.16.71
+## TigerBeetle 0.16.72
 
 Released: 2026-02-06
 

--- a/src/clients/rust/Cargo.toml
+++ b/src/clients/rust/Cargo.toml
@@ -28,4 +28,4 @@ anyhow = "1.0.93"
 
 [dev-dependencies]
 anyhow = "1.0.93"
-futures = "0.3.31"
+futures = { version = "0.3.31", default-features = false, features = ["executor"] }


### PR DESCRIPTION
Due to github outages, we had to republish the release 0.16.71 with an incremented version number.

edit: To unbreak CI, we need to combine this change with the changes from this [PR](https://github.com/tigerbeetle/tigerbeetle/pull/3512)