### PR TITLE
io/linux: refactor event loop

### DIFF
--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -167,10 +167,12 @@ pub const Stats = struct {
     const Timings = struct {
         time_callbacks: stdx.Duration = .ms(0),
         time_run_for_ns: stdx.Duration = .ms(0),
+        time_kernel: stdx.Duration = .ms(0),
 
         pub fn add(total: *Timings, increment: Timings) void {
             total.time_callbacks.ns +|= increment.time_callbacks.ns;
             total.time_run_for_ns.ns +|= increment.time_run_for_ns.ns;
+            total.time_kernel.ns +|= increment.time_kernel.ns;
         }
     };
 
@@ -178,6 +180,7 @@ pub const Stats = struct {
         if (stats.tracer) |tracer| {
             tracer.timing(.loop_run_for_ns, stats.window.time_run_for_ns);
             tracer.timing(.loop_callbacks, stats.window.time_callbacks);
+            tracer.timing(.loop_kernel, stats.window.time_kernel);
         }
         stats.total.add(stats.window);
         stats.window = .{};

--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -161,14 +161,17 @@ pub const Stats = struct {
     const Timings = struct {
         time_callbacks: stdx.Duration = .ms(0),
         time_run_for_ns: stdx.Duration = .ms(0),
+        time_kernel: stdx.Duration = .ms(0),
 
         pub fn time_since(now: Timings, earlier: Timings) Timings {
             assert(now.time_callbacks.ns >= earlier.time_callbacks.ns);
             assert(now.time_run_for_ns.ns >= earlier.time_run_for_ns.ns);
+            assert(now.time_kernel.ns >= earlier.time_kernel.ns);
 
             return .{
                 .time_callbacks = now.time_callbacks.subtract(earlier.time_callbacks),
                 .time_run_for_ns = now.time_run_for_ns.subtract(earlier.time_run_for_ns),
+                .time_kernel = now.time_kernel.subtract(earlier.time_kernel),
             };
         }
     };
@@ -177,6 +180,8 @@ pub const Stats = struct {
     earlier: Timings = .{},
     tracer: ?*Tracer = null,
 
+    syscalls: u64 = 0,
+
     pub fn trace(stats: *Stats) void {
         if (stats.tracer) |tracer| {
             const timings_delta = stats.now.time_since(stats.earlier);
@@ -184,6 +189,8 @@ pub const Stats = struct {
 
             tracer.timing(.loop_run_for_ns, timings_delta.time_run_for_ns);
             tracer.timing(.loop_callbacks, timings_delta.time_callbacks);
+            tracer.timing(.loop_kernel, timings_delta.time_kernel);
+            tracer.gauge(.loop_syscalls, stats.syscalls);
         }
     }
 };

--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -27,6 +27,8 @@ pub const ListenOptions = struct {
     backlog: u31,
 };
 
+pub const NextTickSource = enum { lsm, vsr };
+
 pub fn listen(
     fd: posix.socket_t,
     address: std.net.Address,

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -57,9 +57,10 @@ pub const IO = struct {
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
         assert(!self.run_for_ns_active);
         self.run_for_ns_active = true;
-        defer self.run_for_ns_active = false;
-        defer assert(self.run_for_ns_active);
-
+        defer {
+            assert(self.run_for_ns_active);
+            self.run_for_ns_active = false;
+        }
         defer self.stats.trace();
 
         var timer = try std.time.Timer.start();
@@ -184,7 +185,7 @@ pub const IO = struct {
         while (timeouts_iterator.next()) |completion| {
 
             // NOTE: We could cache `now` above the loop but monotonic() should be cheap to call.
-            const now = self.time_os.time().monotonic().ns;
+            const now = self.time_os.monotonic().ns;
             const expires = completion.operation.timeout.expires;
 
             // NOTE: remove() could be O(1) here with a doubly-linked-list
@@ -764,7 +765,7 @@ pub const IO = struct {
             completion,
             .timeout,
             .{
-                .expires = self.time_os.time().monotonic().ns + nanoseconds,
+                .expires = self.time_os.monotonic().ns + nanoseconds,
             },
             struct {
                 fn do_operation(_: anytype) TimeoutError!void {

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -25,6 +25,7 @@ pub const IO = struct {
     timeouts: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_timeouts" }),
     completed: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_completed" }),
     io_pending: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_pending" }),
+    run_for_ns_active: bool = false,
 
     stats: common.Stats = .{},
 
@@ -52,6 +53,9 @@ pub const IO = struct {
     /// The `nanoseconds` argument is a u63 to allow coercion to the i64 used
     /// in the __kernel_timespec struct.
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
+        self.run_for_ns_active = true;
+        defer self.run_for_ns_active = false;
+
         defer self.stats.trace();
 
         var timer = try std.time.Timer.start();

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -804,10 +804,10 @@ pub const IO = struct {
 
     /// Remove all next_tick entries with the given source from the completed queue.
     pub fn reset_next_tick(self: *IO, source: NextTickSource) void {
-        var old = self.completed;
+        var completed = self.completed;
         self.completed.reset();
 
-        while (old.pop()) |completion| {
+        while (completed.pop()) |completion| {
             if (completion.operation == .next_tick and
                 completion.operation.next_tick.source == source)
             {

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -16,6 +16,7 @@ pub const IO = struct {
     pub const TCPOptions = common.TCPOptions;
     pub const ListenOptions = common.ListenOptions;
     pub const Stats = common.Stats;
+    pub const NextTickSource = common.NextTickSource;
 
     kq: fd_t,
     event_id: Event = 0,
@@ -249,6 +250,9 @@ pub const IO = struct {
             buf: [*]const u8,
             len: u32,
             offset: u64,
+        },
+        next_tick: struct {
+            source: NextTickSource,
         },
     };
 
@@ -743,24 +747,8 @@ pub const IO = struct {
         completion: *Completion,
         nanoseconds: u63,
     ) void {
-        // Special case a zero timeout as a yield.
-        if (nanoseconds == 0) {
-            completion.* = .{
-                .link = .{},
-                .context = context,
-                .operation = undefined,
-                .callback = struct {
-                    fn on_complete(_io: *IO, _completion: *Completion) void {
-                        _ = _io;
-                        const _context: Context = @ptrCast(@alignCast(_completion.context));
-                        callback(_context, _completion, {});
-                    }
-                }.on_complete,
-            };
-
-            self.completed.push(completion);
-            return;
-        }
+        // Use `next_tick()` if you're looking for a yield.
+        assert(nanoseconds > 0);
 
         self.submit(
             context,
@@ -776,6 +764,49 @@ pub const IO = struct {
                 }
             },
         );
+    }
+
+    pub const NextTickResult = void;
+
+    /// Schedule a deferred callback that doesn't involve kernel IO.
+    pub fn next_tick(
+        self: *IO,
+        comptime Context: type,
+        context: Context,
+        comptime callback: fn (
+            context: Context,
+            completion: *Completion,
+            result: NextTickResult,
+        ) void,
+        completion: *Completion,
+        source: NextTickSource,
+    ) void {
+        completion.* = .{
+            .link = .{},
+            .context = context,
+            .operation = .{ .next_tick = .{ .source = source } },
+            .callback = struct {
+                fn on_complete(_: *IO, _completion: *Completion) void {
+                    callback(@ptrCast(@alignCast(_completion.context)), _completion, {});
+                }
+            }.on_complete,
+        };
+        self.completed.push(completion);
+    }
+
+    /// Remove all next_tick entries with the given source from the completed queue.
+    pub fn reset_next_tick(self: *IO, source: NextTickSource) void {
+        var old = self.completed;
+        self.completed.reset();
+
+        while (old.pop()) |completion| {
+            if (completion.operation == .next_tick and
+                completion.operation.next_tick.source == source)
+            {
+                continue;
+            }
+            self.completed.push(completion);
+        }
     }
 
     pub const WriteError = posix.PWriteError;

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -46,6 +46,8 @@ pub const IO = struct {
 
     /// Pass all queued submissions to the kernel and peek for completions.
     pub fn run(self: *IO) !void {
+        assert(!self.run_for_ns_active);
+
         return self.flush(false);
     }
 
@@ -55,6 +57,7 @@ pub const IO = struct {
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
         self.run_for_ns_active = true;
         defer self.run_for_ns_active = false;
+        defer assert(self.run_for_ns_active);
 
         defer self.stats.trace();
 

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -55,6 +55,7 @@ pub const IO = struct {
     /// The `nanoseconds` argument is a u63 to allow coercion to the i64 used
     /// in the __kernel_timespec struct.
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
+        assert(!self.run_for_ns_active);
         self.run_for_ns_active = true;
         defer self.run_for_ns_active = false;
         defer assert(self.run_for_ns_active);

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -466,6 +466,8 @@ pub const IO = struct {
         self.enqueue(options.completion);
     }
 
+    pub const NextTickResult = void;
+
     /// Schedule a deferred callback that doesn't involve kernel IO.
     pub fn next_tick(
         self: *IO,
@@ -488,14 +490,12 @@ pub const IO = struct {
         self.completed.push(completion);
     }
 
-    pub const NextTickResult = void;
-
     /// Remove all next_tick entries with the given source from the completed queue.
     pub fn reset_next_tick(self: *IO, source: NextTickSource) void {
-        var old = self.completed;
+        var completed = self.completed;
         self.completed.reset();
 
-        while (old.pop()) |completion| {
+        while (completed.pop()) |completion| {
             if (completion.operation == .next_tick and
                 completion.operation.next_tick.source == source)
             {

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -241,7 +241,6 @@ pub const IO = struct {
 
         const sqe = self.ring.get_sqe() catch |err| switch (err) {
             error.SubmissionQueueFull => blk: {
-                // FIXME: Currently warns on format.
                 std.log.warn(
                     "enqueue: submission queue full. flushing. consider resizing IO.init()",
                     .{},

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -26,11 +26,7 @@ pub const IO = struct {
 
     ring: IO_Uring,
 
-    /// Operations not yet submitted to the kernel and waiting on available space in the
-    /// submission queue.
-    unqueued: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_unqueued" }),
-
-    /// Completions that are ready to have their callbacks run.
+    /// Completions and deferred callbacks that are ready to have their callbacks run.
     completed: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_completed" }),
 
     // TODO Track these as metrics:
@@ -41,7 +37,7 @@ pub const IO = struct {
     /// - in the submission queue, or
     /// - in the kernel, or
     /// - in the completion queue, or
-    /// - in the `completed` list (excluding zero-duration timeouts).
+    /// - in the `completed` list but only when operation != .next_tick.
     awaiting: CompletionList = .{},
 
     // This is the completion that performs the cancellation.
@@ -63,10 +59,13 @@ pub const IO = struct {
 
     stats: common.Stats = .{},
 
+    run_for_ns_active: bool = false,
+
     pub fn init(entries: u12, flags: u32) !IO {
         // Detect the linux version to ensure that we support all io_uring ops used.
         const uts = posix.uname();
         const version = try parse_dirty_semver(&uts.release);
+        // FIXME: Bump this as required.
         if (version.order(std.SemanticVersion{ .major = 5, .minor = 5, .patch = 0 }) == .lt) {
             @panic("Linux kernel 5.5 or greater is required for io_uring OP_ACCEPT");
         }
@@ -94,26 +93,19 @@ pub const IO = struct {
     /// Pass all queued submissions to the kernel and peek for completions.
     pub fn run(self: *IO) !void {
         assert(self.cancel_all_status != .done);
+        assert(!self.run_for_ns_active);
 
-        // We assume that all timeouts submitted by `run_for_ns()` will be reaped by `run_for_ns()`
-        // and that `tick()` and `run_for_ns()` cannot be run concurrently.
-        // Therefore `timeouts` here will never be decremented and `etime` will always be false.
-        var timeouts: usize = 0;
-        var etime = false;
+        try self.flush_submissions(0);
+        try self.flush_completions(0);
 
-        try self.flush(0, &timeouts, &etime);
-        assert(etime == false);
+        while (self.completed.count() > 0) {
+            try self.run_callback();
+        }
 
-        // Flush any SQEs that were queued while running completion callbacks in `flush()`:
+        // Flush any SQEs that were queued while running completion callbacks in `run_callback()`:
         // This is an optimization to avoid delaying submissions until the next tick.
         // At the same time, we do not flush any ready CQEs since SQEs may complete synchronously.
-        // We guard against an io_uring_enter() syscall if we know we do not have any queued SQEs.
-        // We cannot use `self.ring.sq_ready()` here since this counts flushed and unflushed SQEs.
-        const queued = self.ring.sq.sqe_tail -% self.ring.sq.sqe_head;
-        if (queued > 0) {
-            try self.flush_submissions(0, &timeouts, &etime);
-            assert(etime == false);
-        }
+        try self.flush_submissions(0);
     }
 
     /// Pass all queued submissions to the kernel and run for `nanoseconds`.
@@ -123,125 +115,86 @@ pub const IO = struct {
         assert(self.cancel_all_status != .done);
         defer self.stats.trace();
 
+        self.run_for_ns_active = true;
+        defer self.run_for_ns_active = false;
+
         var timer = try std.time.Timer.start();
         defer self.stats.now.time_run_for_ns.ns += timer.read();
 
-        // We must use the same clock source used by io_uring (CLOCK_MONOTONIC) since we specify the
-        // timeout below as an absolute value. Otherwise, we may deadlock if the clock sources are
-        // dramatically different. Any kernel that supports io_uring will support CLOCK_MONOTONIC.
-        const current_ts = posix.clock_gettime(posix.CLOCK.MONOTONIC) catch unreachable;
-        // The absolute CLOCK_MONOTONIC time after which we may return from this function:
-        const timeout_ts: os.linux.kernel_timespec = .{
-            .sec = current_ts.sec,
-            .nsec = current_ts.nsec + nanoseconds,
-        };
-        var timeouts: usize = 0;
-        var etime = false;
-        while (!etime) {
-            const timeout_sqe = self.ring.get_sqe() catch blk: {
-                // The submission queue is full, so flush submissions to make space:
-                try self.flush_submissions(0, &timeouts, &etime);
-                break :blk self.ring.get_sqe() catch unreachable;
-            };
-            // Submit an absolute timeout that will be canceled if any other SQE completes first:
-            timeout_sqe.prep_timeout(&timeout_ts, 1, os.linux.IORING_TIMEOUT_ABS);
-            timeout_sqe.user_data = 0;
-            timeouts += 1;
+        while (timer.read() < nanoseconds) {
+            // If there are callbacks ready to run, don't wait in the kernel: the callbacks may
+            // queue more work, which should be submitted as soon as possible.
+            const block_ns = if (self.completed.count() == 0) nanoseconds -| timer.read() else 0;
 
-            // We don't really want to count this timeout as an io,
-            // but it's tricky to track separately.
-            self.ios_queued += 1;
+            try self.flush_submissions(@intCast(block_ns));
+            try self.flush_completions(0);
 
-            // The amount of time this call will block is bounded by the timeout we just submitted:
-            try self.flush(1, &timeouts, &etime);
+            try self.run_callback();
         }
-        // Reap any remaining timeouts, which reference the timespec in the current stack frame.
-        // The busy loop here is required to avoid a potential deadlock, as the kernel determines
-        // when the timeouts are pushed to the completion queue, not us.
-        while (timeouts > 0) _ = try self.flush_completions(0, &timeouts, &etime);
+
+        // Ditto the optimization in `run()`.
+        try self.flush_submissions(0);
     }
 
-    fn flush(self: *IO, wait_nr: u32, timeouts: *usize, etime: *bool) !void {
-        // Flush any queued SQEs and reuse the same syscall to wait for completions if required:
-        try self.flush_submissions(wait_nr, timeouts, etime);
-        // We can now just peek for any CQEs without waiting and without another syscall:
-        try self.flush_completions(0, timeouts, etime);
-
-        // The SQE array is empty from flush_submissions(). Fill it up with unqueued completions.
-        // This runs before `self.completed` is flushed below to prevent new IO from reserving SQE
-        // slots and potentially starving those in `self.unqueued`.
-        // Loop over a copy to avoid an infinite loop of `enqueue()` re-adding to `self.unqueued`.
-        {
-            var copy = self.unqueued;
-            self.unqueued.reset();
-            while (copy.pop()) |completion| self.enqueue(completion);
+    fn flush_submissions(self: *IO, wait_duration_ns: u63) !void {
+        // We guard against an io_uring_enter() syscall if we know we do not have any queued SQEs.
+        // We cannot use `self.ring.sq_ready()` here since this counts flushed and unflushed SQEs.
+        const queued = self.ring.sq.sqe_tail -% self.ring.sq.sqe_head;
+        if (queued == 0 and wait_duration_ns == 0) {
+            return;
         }
 
-        var timer = try std.time.Timer.start();
+        const wait_nr: u32 = if (wait_duration_ns > 0) 1 else 0;
 
-        // Run completions only after all completions have been flushed:
-        // Loop until all completions are processed. Calls to complete() may queue more work
-        // and extend the duration of the loop, but this is fine as it 1) executes completions
-        // that become ready without going through another syscall from flush_submissions() and
-        // 2) potentially queues more SQEs to take advantage more of the next flush_submissions().
-        while (self.completed.pop()) |completion| {
-            if (completion.operation == .timeout and
-                completion.operation.timeout.timespec.sec == 0 and
-                completion.operation.timeout.timespec.nsec == 0)
-            {
-                // Zero-duration timeouts are a special case, and aren't listed in `awaiting`.
-                maybe(self.awaiting.empty());
-                assert(completion.result == -@as(i32, @intFromEnum(posix.E.TIME)));
-                assert(completion.awaiting_back == null);
-                assert(completion.awaiting_next == null);
-            } else {
-                assert(!self.awaiting.empty());
-                self.awaiting.remove(completion);
-            }
-
-            switch (self.cancel_all_status) {
-                .inactive => completion.complete(),
-                .next => {},
-                .queued => if (completion.operation == .cancel) completion.complete(),
-                .wait => |wait| if (wait.target == completion) {
-                    self.cancel_all_status = .next;
-                },
-                .done => unreachable,
-            }
-        }
-
-        self.stats.now.time_callbacks.ns += timer.read();
-
-        // At this point, unqueued could have completions either by 1) those who didn't get an SQE
-        // during the popping of unqueued or 2) completion.complete() which start new IO. These
-        // unqueued completions will get priority to acquiring SQEs on the next flush().
-    }
-
-    fn flush_completions(self: *IO, wait_nr: u32, timeouts: *usize, etime: *bool) !void {
-        var cqes: [256]io_uring_cqe = undefined;
-        var wait_remaining = wait_nr;
         while (true) {
-            // Guard against waiting indefinitely (if there are too few requests inflight),
-            // especially if this is not the first time round the loop:
-            const completed = self.ring.copy_cqes(&cqes, wait_remaining) catch |err| switch (err) {
+            var timer = std.time.Timer.start() catch unreachable;
+            // Doesn't account for flush_completions, which is assumed to be very rare and fast.
+            defer self.stats.now.time_kernel.ns += timer.read();
+
+            const submitted = submit_and_wait_timeout(
+                &self.ring,
+                wait_nr,
+                wait_duration_ns,
+            ) catch |err| switch (err) {
+                error.SignalInterrupt => continue,
+                // Wait for some completions and then try again:
+                // See https://github.com/axboe/liburing/issues/281 re: error.SystemResources.
+                // Be careful also that copy_cqes() will flush before entering to wait (it does):
+                // https://github.com/axboe/liburing/commit/35c199c48dfd54ad46b96e386882e7ac341314c5
+                error.CompletionQueueOvercommitted, error.SystemResources => {
+                    std.log.warn(
+                        "flush_submissions: completion queue overcommitted.",
+                        .{},
+                    );
+                    try self.flush_completions(1);
+                    continue;
+                },
+                else => return err,
+            };
+
+            self.stats.syscalls += 1;
+            self.ios_queued -= submitted;
+            self.ios_in_kernel += submitted;
+
+            break;
+        }
+    }
+
+    /// Copy completions out of the ring and into `self.completed`.
+    fn flush_completions(self: *IO, wait_nr: u32) !void {
+        var cqes: [256]io_uring_cqe = undefined;
+        while (true) {
+            const completed = self.ring.copy_cqes(&cqes, wait_nr) catch |err| switch (err) {
                 error.SignalInterrupt => continue,
                 else => return err,
             };
-            if (completed > wait_remaining) wait_remaining = 0 else wait_remaining -= completed;
+
             for (cqes[0..completed]) |cqe| {
                 self.ios_in_kernel -= 1;
 
-                if (cqe.user_data == 0) {
-                    timeouts.* -= 1;
-                    // We are only done if the timeout submitted was completed due to time, not if
-                    // it was completed due to the completion of an event, in which case `cqe.res`
-                    // would be 0. It is possible for multiple timeout operations to complete at the
-                    // same time if the nanoseconds value passed to `run_for_ns()` is very short.
-                    if (-cqe.res == @intFromEnum(posix.E.TIME)) etime.* = true;
-                    continue;
-                }
                 const completion: *Completion = @ptrFromInt(cqe.user_data);
                 completion.result = cqe.res;
+
                 // We do not run the completion here (instead appending to a linked list) to avoid:
                 // * recursion through `flush_submissions()` and `flush_completions()`,
                 // * unbounded stack usage, and
@@ -249,29 +202,34 @@ pub const IO = struct {
                 self.completed.push(completion);
             }
 
-            if (completed < cqes.len) break;
+            break;
         }
     }
 
-    fn flush_submissions(self: *IO, wait_nr: u32, timeouts: *usize, etime: *bool) !void {
-        while (true) {
-            const submitted = self.ring.submit_and_wait(wait_nr) catch |err| switch (err) {
-                error.SignalInterrupt => continue,
-                // Wait for some completions and then try again:
-                // See https://github.com/axboe/liburing/issues/281 re: error.SystemResources.
-                // Be careful also that copy_cqes() will flush before entering to wait (it does):
-                // https://github.com/axboe/liburing/commit/35c199c48dfd54ad46b96e386882e7ac341314c5
-                error.CompletionQueueOvercommitted, error.SystemResources => {
-                    try self.flush_completions(1, timeouts, etime);
-                    continue;
-                },
-                else => return err,
-            };
+    fn run_callback(self: *IO) !void {
+        const completion = self.completed.pop() orelse return;
 
-            self.ios_queued -= submitted;
-            self.ios_in_kernel += submitted;
+        var timer = try std.time.Timer.start();
+        defer self.stats.now.time_callbacks.ns += timer.read();
 
-            break;
+        if (completion.operation == .next_tick) {
+            // next_tick completions are never submitted to the kernel,
+            // so they are not in `awaiting` and bypass the cancel logic.
+            completion.complete();
+            return;
+        }
+
+        assert(!self.awaiting.empty());
+        self.awaiting.remove(completion);
+
+        switch (self.cancel_all_status) {
+            .inactive => completion.complete(),
+            .next => {},
+            .queued => if (completion.operation == .cancel) completion.complete(),
+            .wait => |wait| if (wait.target == completion) {
+                self.cancel_all_status = .next;
+            },
+            .done => unreachable,
         }
     }
 
@@ -283,9 +241,17 @@ pub const IO = struct {
         }
 
         const sqe = self.ring.get_sqe() catch |err| switch (err) {
-            error.SubmissionQueueFull => {
-                self.unqueued.push(completion);
-                return;
+            error.SubmissionQueueFull => blk: {
+                // FIXME: Currently warns on format.
+                std.log.warn(
+                    "enqueue: submission queue full. flushing. consider resizing IO.init()",
+                    .{},
+                );
+
+                self.flush_submissions(0) catch unreachable;
+                break :blk self.ring.get_sqe() catch |err_inner| switch (err_inner) {
+                    error.SubmissionQueueFull => unreachable,
+                };
             },
         };
         completion.prep(sqe);
@@ -320,9 +286,6 @@ pub const IO = struct {
         defer self.cancel_all_status = .done;
 
         self.cancel_all_status = .next;
-
-        // Discard any operations that haven't started yet.
-        while (self.unqueued.pop()) |_| {}
 
         while (self.awaiting.tail) |target| {
             assert(!self.awaiting.empty());
@@ -370,6 +333,109 @@ pub const IO = struct {
         };
     }
 
+    /// Like IoUring.submit_and_wait, but uses IORING_ENTER_EXT_ARG to pass a timeout
+    /// directly to io_uring_enter, avoiding the need for separate timeout SQEs.
+    fn submit_and_wait_timeout(ring: *IO_Uring, wait_nr: u32, wait_duration_ns: u63) !u32 {
+        const submitted = ring.flush_sq();
+        var flags: u32 = 0;
+
+        // It only makes sense to have a non-zero wait duration if at least one event is required.
+        // Otherwise, it'll return immediately anyway.
+        if (wait_duration_ns > 0) assert(wait_nr > 0);
+
+        if (ring.sq_ring_needs_enter(&flags) or wait_nr > 0) {
+            if (wait_nr > 0 or (ring.flags & linux.IORING_SETUP_IOPOLL) != 0) {
+                flags |= linux.IORING_ENTER_GETEVENTS;
+            }
+
+            if (wait_nr > 0 and wait_duration_ns > 0) {
+                // Use EXT_ARG to pass the timeout directly to io_uring_enter.
+                flags |= linux.IORING_ENTER_EXT_ARG;
+
+                var ts: linux.kernel_timespec = .{
+                    .sec = wait_duration_ns / std.time.ns_per_s,
+                    .nsec = wait_duration_ns % std.time.ns_per_s,
+                };
+
+                var arg = linux.io_uring_getevents_arg{
+                    .sigmask = 0,
+                    .sigmask_sz = linux.NSIG / 8,
+                    .pad = 0,
+                    .ts = @intFromPtr(&ts),
+                };
+
+                return enter_ext(ring, submitted, wait_nr, flags, &arg) catch |err| switch (err) {
+                    // Timeout expired before min_complete CQEs arrived, but the SQEs
+                    // were still submitted to the kernel by flush_sq() above.
+                    error.TimeoutExpired => submitted,
+                    else => err,
+                };
+            } else {
+                return try ring.enter(submitted, wait_nr, flags);
+            }
+        }
+        return submitted;
+    }
+
+    /// Tell the kernel we have submitted SQEs and/or want to wait for CQEs, with
+    /// IORING_ENTER_EXT_ARG.
+    /// Returns the number of SQEs submitted.
+    fn enter_ext(
+        ring: *IO_Uring,
+        to_submit: u32,
+        min_complete: u32,
+        flags: u32,
+        arg: *linux.io_uring_getevents_arg,
+    ) !u32 {
+        assert(ring.fd >= 0);
+        assert((flags & linux.IORING_ENTER_EXT_ARG) != 0);
+
+        // Can't use linux.io_uring_enter because it hardcodes the size of the arg parameter as
+        // NSIG / 8.
+        const res = linux.syscall6(
+            .io_uring_enter,
+            @as(usize, @bitCast(@as(isize, ring.fd))),
+            to_submit,
+            min_complete,
+            flags,
+            @intFromPtr(arg),
+            @sizeOf(linux.io_uring_getevents_arg),
+        );
+
+        switch (linux.E.init(res)) {
+            .SUCCESS => {},
+            // The kernel was unable to allocate memory or ran out of resources for the request.
+            // The application should wait for some completions and try again:
+            .AGAIN => return error.SystemResources,
+            // The SQE `fd` is invalid, or IOSQE_FIXED_FILE was set but no files were registered:
+            .BADF => return error.FileDescriptorInvalid,
+            // The file descriptor is valid, but the ring is not in the right state.
+            // See io_uring_register(2) for how to enable the ring.
+            .BADFD => return error.FileDescriptorInBadState,
+            // The application attempted to overcommit the number of requests it can have pending.
+            // The application should wait for some completions and try again:
+            .BUSY => return error.CompletionQueueOvercommitted,
+            // The SQE is invalid, or valid but the ring was setup with IORING_SETUP_IOPOLL:
+            .INVAL => return error.SubmissionQueueEntryInvalid,
+            // The buffer is outside the process' accessible address space, or IORING_OP_READ_FIXED
+            // or IORING_OP_WRITE_FIXED was specified but no buffers were registered, or the range
+            // described by `addr` and `len` is not within the buffer registered at `buf_index`:
+            .FAULT => return error.BufferInvalid,
+            .NXIO => return error.RingShuttingDown,
+            // The kernel believes our `self.fd` does not refer to an io_uring instance,
+            // or the opcode is valid but not supported by this kernel (more likely):
+            .OPNOTSUPP => return error.OpcodeNotSupported,
+            // The operation was interrupted by a delivery of a signal before it could complete.
+            // This can happen while waiting for events with IORING_ENTER_GETEVENTS:
+            .INTR => return error.SignalInterrupt,
+            // A timeout was specified in arg, and it has expired.
+            .TIME => return error.TimeoutExpired,
+            else => |errno| return stdx.unexpected_errno("io_uring_enter", errno),
+        }
+
+        return @as(u32, @intCast(res));
+    }
+
     pub const CancelError = error{
         NotRunning,
         NotInterruptable,
@@ -397,6 +463,47 @@ pub const IO = struct {
         };
 
         self.enqueue(options.completion);
+    }
+
+    pub const NextTickSource = enum { lsm, vsr };
+
+    /// Schedule a deferred callback that doesn't involve kernel IO.
+    pub fn next_tick(
+        self: *IO,
+        comptime Context: type,
+        context: Context,
+        comptime callback: fn (
+            context: Context,
+            completion: *Completion,
+            result: NextTickResult,
+        ) void,
+        completion: *Completion,
+        source: NextTickSource,
+    ) void {
+        completion.* = .{
+            .io = self,
+            .context = context,
+            .callback = erase_types(Context, NextTickResult, callback),
+            .operation = .{ .next_tick = .{ .source = source } },
+        };
+        self.completed.push(completion);
+    }
+
+    pub const NextTickResult = void;
+
+    /// Remove all next_tick entries with the given source from the completed queue.
+    pub fn reset_next_tick(self: *IO, source: NextTickSource) void {
+        var old = self.completed;
+        self.completed.reset();
+
+        while (old.pop()) |completion| {
+            if (completion.operation == .next_tick and
+                completion.operation.next_tick.source == source)
+            {
+                continue;
+            }
+            self.completed.push(completion);
+        }
     }
 
     /// This struct holds the data needed for a single io_uring operation.
@@ -482,6 +589,7 @@ pub const IO = struct {
                         op.offset,
                     );
                 },
+                .next_tick => unreachable, // Never submitted to the kernel.
             }
             sqe.user_data = @intFromPtr(completion);
         }
@@ -819,6 +927,10 @@ pub const IO = struct {
                     };
                     completion.callback(completion.context, completion, &result);
                 },
+                .next_tick => {
+                    const result: NextTickResult = {};
+                    completion.callback(completion.context, completion, &result);
+                },
             }
         }
     };
@@ -877,6 +989,9 @@ pub const IO = struct {
             fd: fd_t,
             buffer: []const u8,
             offset: u64,
+        },
+        next_tick: struct {
+            source: NextTickSource,
         },
     };
 
@@ -1267,6 +1382,9 @@ pub const IO = struct {
         completion: *Completion,
         nanoseconds: u63,
     ) void {
+        // Use `next_tick()` if you're looking for a yield.
+        assert(nanoseconds > 0);
+
         completion.* = .{
             .io = self,
             .context = context,
@@ -1277,13 +1395,6 @@ pub const IO = struct {
                 },
             },
         };
-
-        // Special case a zero timeout as a yield.
-        if (nanoseconds == 0) {
-            completion.result = -@as(i32, @intFromEnum(posix.E.TIME));
-            self.completed.push(completion);
-            return;
-        }
 
         self.enqueue(completion);
     }

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -10,6 +10,7 @@ const log = std.log.scoped(.io);
 
 const constants = @import("../constants.zig");
 const stdx = @import("stdx");
+const TimeOS = @import("../time.zig").TimeOS;
 const common = @import("./common.zig");
 const QueueType = @import("../queue.zig").QueueType;
 const buffer_limit = @import("../io.zig").buffer_limit;
@@ -58,6 +59,8 @@ pub const IO = struct {
     } = .inactive,
 
     stats: common.Stats = .{},
+
+    time_os: TimeOS = .{},
 
     run_for_ns_active: bool = false,
 
@@ -116,18 +119,23 @@ pub const IO = struct {
 
         assert(!self.run_for_ns_active);
         self.run_for_ns_active = true;
-        defer self.run_for_ns_active = false;
-        defer assert(self.run_for_ns_active);
+        defer {
+            assert(self.run_for_ns_active);
+            self.run_for_ns_active = false;
+        }
 
         defer self.stats.trace();
 
         var timer = try std.time.Timer.start();
         defer self.stats.window.time_run_for_ns.ns += timer.read();
 
-        while (timer.read() < nanoseconds) {
+        var now = self.time_os.monotonic();
+        const deadline = now.add(.{ .ns = nanoseconds });
+
+        while (now.ns < deadline.ns) : (now = self.time_os.monotonic()) {
             // If there are callbacks ready to run, don't wait in the kernel: the callbacks may
             // queue more work, which should be submitted as soon as possible.
-            const block_ns = if (self.completed.count() == 0) nanoseconds -| timer.read() else 0;
+            const block_ns = if (self.completed.count() == 0) deadline.ns -| now.ns else 0;
 
             try self.flush_submissions(@intCast(block_ns));
             try self.flush_completions(0);
@@ -151,7 +159,8 @@ pub const IO = struct {
 
         while (true) {
             var timer = std.time.Timer.start() catch unreachable;
-            // Doesn't account for flush_completions, which is assumed to be very rare and fast.
+            // Doesn't account for flush_completions below; which indicates a bad assumption either
+            // on our sizing of the loop, or a bug in the kernel.
             defer self.stats.window.time_kernel.ns += timer.read();
 
             const submitted = submit_and_wait_timeout(
@@ -165,11 +174,14 @@ pub const IO = struct {
                 // Be careful also that copy_cqes() will flush before entering to wait (it does):
                 // https://github.com/axboe/liburing/commit/35c199c48dfd54ad46b96e386882e7ac341314c5
                 error.CompletionQueueOvercommitted, error.SystemResources => {
-                    std.log.warn(
+                    log.err(
                         "flush_submissions: completion queue overcommitted.",
                         .{},
                     );
+
+                    // NB: enforcing timeout here is impossible, so don't even try.
                     try self.flush_completions(1);
+
                     continue;
                 },
                 else => return err,
@@ -244,7 +256,7 @@ pub const IO = struct {
 
         const sqe = self.ring.get_sqe() catch |err| switch (err) {
             error.SubmissionQueueFull => blk: {
-                std.log.warn(
+                log.warn(
                     "enqueue: submission queue full. flushing. consider resizing IO.init()",
                     .{},
                 );
@@ -349,31 +361,32 @@ pub const IO = struct {
                 flags |= linux.IORING_ENTER_GETEVENTS;
             }
 
+            // Use EXT_ARG to pass the timeout directly to io_uring_enter.
+            flags |= linux.IORING_ENTER_EXT_ARG;
+
+            var arg = linux.io_uring_getevents_arg{
+                .sigmask = 0,
+                .sigmask_sz = linux.NSIG / 8,
+                .pad = 0,
+                .ts = 0,
+            };
+
+            var ts: linux.kernel_timespec = .{
+                .sec = wait_duration_ns / std.time.ns_per_s,
+                .nsec = wait_duration_ns % std.time.ns_per_s,
+            };
+
+            // Don't be tempted to move `ts` inside here: it's on the stack, and referenced by arg.
             if (wait_nr > 0 and wait_duration_ns > 0) {
-                // Use EXT_ARG to pass the timeout directly to io_uring_enter.
-                flags |= linux.IORING_ENTER_EXT_ARG;
-
-                var ts: linux.kernel_timespec = .{
-                    .sec = wait_duration_ns / std.time.ns_per_s,
-                    .nsec = wait_duration_ns % std.time.ns_per_s,
-                };
-
-                var arg = linux.io_uring_getevents_arg{
-                    .sigmask = 0,
-                    .sigmask_sz = linux.NSIG / 8,
-                    .pad = 0,
-                    .ts = @intFromPtr(&ts),
-                };
-
-                return enter_ext(ring, submitted, wait_nr, flags, &arg) catch |err| switch (err) {
-                    // Timeout expired before min_complete CQEs arrived, but the SQEs
-                    // were still submitted to the kernel by flush_sq() above.
-                    error.TimeoutExpired => submitted,
-                    else => err,
-                };
-            } else {
-                return try ring.enter(submitted, wait_nr, flags);
+                arg.ts = @intFromPtr(&ts);
             }
+
+            return enter_ext(ring, submitted, wait_nr, flags, &arg) catch |err| switch (err) {
+                // Timeout expired before min_complete CQEs arrived, but the SQEs
+                // were still submitted to the kernel by flush_sq() above.
+                error.TimeoutExpired => submitted,
+                else => err,
+            };
         }
         return submitted;
     }

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -21,6 +21,7 @@ pub const IO = struct {
     pub const TCPOptions = common.TCPOptions;
     pub const ListenOptions = common.ListenOptions;
     pub const Stats = common.Stats;
+    pub const NextTickSource = common.NextTickSource;
     const CompletionList = DoublyLinkedListType(Completion, .awaiting_back, .awaiting_next);
 
     ring: IO_Uring,
@@ -462,8 +463,6 @@ pub const IO = struct {
 
         self.enqueue(options.completion);
     }
-
-    pub const NextTickSource = enum { lsm, vsr };
 
     /// Schedule a deferred callback that doesn't involve kernel IO.
     pub fn next_tick(

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -26,11 +26,7 @@ pub const IO = struct {
 
     ring: IO_Uring,
 
-    /// Operations not yet submitted to the kernel and waiting on available space in the
-    /// submission queue.
-    unqueued: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_unqueued" }),
-
-    /// Completions that are ready to have their callbacks run.
+    /// Completions and deferred callbacks that are ready to have their callbacks run.
     completed: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_completed" }),
 
     // TODO Track these as metrics:
@@ -41,7 +37,7 @@ pub const IO = struct {
     /// - in the submission queue, or
     /// - in the kernel, or
     /// - in the completion queue, or
-    /// - in the `completed` list (excluding zero-duration timeouts).
+    /// - in the `completed` list but only when operation != .next_tick.
     awaiting: CompletionList = .{},
 
     // This is the completion that performs the cancellation.
@@ -63,10 +59,13 @@ pub const IO = struct {
 
     stats: common.Stats = .{},
 
+    run_for_ns_active: bool = false,
+
     pub fn init(entries: u12, flags: u32) !IO {
         // Detect the linux version to ensure that we support all io_uring ops used.
         const uts = posix.uname();
         const version = try parse_dirty_semver(&uts.release);
+        // FIXME: Bump this as required.
         if (version.order(std.SemanticVersion{ .major = 5, .minor = 5, .patch = 0 }) == .lt) {
             @panic("Linux kernel 5.5 or greater is required for io_uring OP_ACCEPT");
         }
@@ -94,26 +93,19 @@ pub const IO = struct {
     /// Pass all queued submissions to the kernel and peek for completions.
     pub fn run(self: *IO) !void {
         assert(self.cancel_all_status != .done);
+        assert(!self.run_for_ns_active);
 
-        // We assume that all timeouts submitted by `run_for_ns()` will be reaped by `run_for_ns()`
-        // and that `tick()` and `run_for_ns()` cannot be run concurrently.
-        // Therefore `timeouts` here will never be decremented and `etime` will always be false.
-        var timeouts: usize = 0;
-        var etime = false;
+        try self.flush_submissions(0);
+        try self.flush_completions(0);
 
-        try self.flush(0, &timeouts, &etime);
-        assert(etime == false);
+        while (self.completed.count() > 0) {
+            try self.run_callback();
+        }
 
-        // Flush any SQEs that were queued while running completion callbacks in `flush()`:
+        // Flush any SQEs that were queued while running completion callbacks in `run_callback()`:
         // This is an optimization to avoid delaying submissions until the next tick.
         // At the same time, we do not flush any ready CQEs since SQEs may complete synchronously.
-        // We guard against an io_uring_enter() syscall if we know we do not have any queued SQEs.
-        // We cannot use `self.ring.sq_ready()` here since this counts flushed and unflushed SQEs.
-        const queued = self.ring.sq.sqe_tail -% self.ring.sq.sqe_head;
-        if (queued > 0) {
-            try self.flush_submissions(0, &timeouts, &etime);
-            assert(etime == false);
-        }
+        try self.flush_submissions(0);
     }
 
     /// Pass all queued submissions to the kernel and run for `nanoseconds`.
@@ -123,146 +115,58 @@ pub const IO = struct {
         assert(self.cancel_all_status != .done);
         defer self.stats.trace();
 
+        self.run_for_ns_active = true;
+        defer self.run_for_ns_active = false;
+
         var timer = try std.time.Timer.start();
         defer self.stats.window.time_run_for_ns.ns += timer.read();
 
-        // We must use the same clock source used by io_uring (CLOCK_MONOTONIC) since we specify the
-        // timeout below as an absolute value. Otherwise, we may deadlock if the clock sources are
-        // dramatically different. Any kernel that supports io_uring will support CLOCK_MONOTONIC.
-        const current_ts = posix.clock_gettime(posix.CLOCK.MONOTONIC) catch unreachable;
-        // The absolute CLOCK_MONOTONIC time after which we may return from this function:
-        const timeout_ts: os.linux.kernel_timespec = .{
-            .sec = current_ts.sec,
-            .nsec = current_ts.nsec + nanoseconds,
-        };
-        var timeouts: usize = 0;
-        var etime = false;
-        while (!etime) {
-            const timeout_sqe = self.ring.get_sqe() catch blk: {
-                // The submission queue is full, so flush submissions to make space:
-                try self.flush_submissions(0, &timeouts, &etime);
-                break :blk self.ring.get_sqe() catch unreachable;
-            };
-            // Submit an absolute timeout that will be canceled if any other SQE completes first:
-            timeout_sqe.prep_timeout(&timeout_ts, 1, os.linux.IORING_TIMEOUT_ABS);
-            timeout_sqe.user_data = 0;
-            timeouts += 1;
+        while (timer.read() < nanoseconds) {
+            // If there are callbacks ready to run, don't wait in the kernel: the callbacks may
+            // queue more work, which should be submitted as soon as possible.
+            const block_ns = if (self.completed.count() == 0) nanoseconds -| timer.read() else 0;
 
-            // We don't really want to count this timeout as an io,
-            // but it's tricky to track separately.
-            self.ios_queued += 1;
+            try self.flush_submissions(@intCast(block_ns));
+            try self.flush_completions(0);
 
-            // The amount of time this call will block is bounded by the timeout we just submitted:
-            try self.flush(1, &timeouts, &etime);
+            try self.run_callback();
         }
-        // Reap any remaining timeouts, which reference the timespec in the current stack frame.
-        // The busy loop here is required to avoid a potential deadlock, as the kernel determines
-        // when the timeouts are pushed to the completion queue, not us.
-        while (timeouts > 0) _ = try self.flush_completions(0, &timeouts, &etime);
+
+        // Ditto the optimization in `run()`.
+        try self.flush_submissions(0);
     }
 
-    fn flush(self: *IO, wait_nr: u32, timeouts: *usize, etime: *bool) !void {
-        // Flush any queued SQEs and reuse the same syscall to wait for completions if required:
-        try self.flush_submissions(wait_nr, timeouts, etime);
-        // We can now just peek for any CQEs without waiting and without another syscall:
-        try self.flush_completions(0, timeouts, etime);
-
-        // The SQE array is empty from flush_submissions(). Fill it up with unqueued completions.
-        // This runs before `self.completed` is flushed below to prevent new IO from reserving SQE
-        // slots and potentially starving those in `self.unqueued`.
-        // Loop over a copy to avoid an infinite loop of `enqueue()` re-adding to `self.unqueued`.
-        {
-            var copy = self.unqueued;
-            self.unqueued.reset();
-            while (copy.pop()) |completion| self.enqueue(completion);
+    fn flush_submissions(self: *IO, wait_duration_ns: u63) !void {
+        // We guard against an io_uring_enter() syscall if we know we do not have any queued SQEs.
+        // We cannot use `self.ring.sq_ready()` here since this counts flushed and unflushed SQEs.
+        const queued = self.ring.sq.sqe_tail -% self.ring.sq.sqe_head;
+        if (queued == 0 and wait_duration_ns == 0) {
+            return;
         }
 
-        var timer = try std.time.Timer.start();
+        const wait_nr: u32 = if (wait_duration_ns > 0) 1 else 0;
 
-        // Run completions only after all completions have been flushed:
-        // Loop until all completions are processed. Calls to complete() may queue more work
-        // and extend the duration of the loop, but this is fine as it 1) executes completions
-        // that become ready without going through another syscall from flush_submissions() and
-        // 2) potentially queues more SQEs to take advantage more of the next flush_submissions().
-        while (self.completed.pop()) |completion| {
-            if (completion.operation == .timeout and
-                completion.operation.timeout.timespec.sec == 0 and
-                completion.operation.timeout.timespec.nsec == 0)
-            {
-                // Zero-duration timeouts are a special case, and aren't listed in `awaiting`.
-                maybe(self.awaiting.empty());
-                assert(completion.result == -@as(i32, @intFromEnum(posix.E.TIME)));
-                assert(completion.awaiting_back == null);
-                assert(completion.awaiting_next == null);
-            } else {
-                assert(!self.awaiting.empty());
-                self.awaiting.remove(completion);
-            }
-
-            switch (self.cancel_all_status) {
-                .inactive => completion.complete(),
-                .next => {},
-                .queued => if (completion.operation == .cancel) completion.complete(),
-                .wait => |wait| if (wait.target == completion) {
-                    self.cancel_all_status = .next;
-                },
-                .done => unreachable,
-            }
-        }
-
-        self.stats.window.time_callbacks.ns += timer.read();
-
-        // At this point, unqueued could have completions either by 1) those who didn't get an SQE
-        // during the popping of unqueued or 2) completion.complete() which start new IO. These
-        // unqueued completions will get priority to acquiring SQEs on the next flush().
-    }
-
-    fn flush_completions(self: *IO, wait_nr: u32, timeouts: *usize, etime: *bool) !void {
-        var cqes: [256]io_uring_cqe = undefined;
-        var wait_remaining = wait_nr;
         while (true) {
-            // Guard against waiting indefinitely (if there are too few requests inflight),
-            // especially if this is not the first time round the loop:
-            const completed = self.ring.copy_cqes(&cqes, wait_remaining) catch |err| switch (err) {
-                error.SignalInterrupt => continue,
-                else => return err,
-            };
-            if (completed > wait_remaining) wait_remaining = 0 else wait_remaining -= completed;
-            for (cqes[0..completed]) |cqe| {
-                self.ios_in_kernel -= 1;
+            var timer = std.time.Timer.start() catch unreachable;
+            // Doesn't account for flush_completions, which is assumed to be very rare and fast.
+            defer self.stats.window.time_kernel.ns += timer.read();
 
-                if (cqe.user_data == 0) {
-                    timeouts.* -= 1;
-                    // We are only done if the timeout submitted was completed due to time, not if
-                    // it was completed due to the completion of an event, in which case `cqe.res`
-                    // would be 0. It is possible for multiple timeout operations to complete at the
-                    // same time if the nanoseconds value passed to `run_for_ns()` is very short.
-                    if (-cqe.res == @intFromEnum(posix.E.TIME)) etime.* = true;
-                    continue;
-                }
-                const completion: *Completion = @ptrFromInt(cqe.user_data);
-                completion.result = cqe.res;
-                // We do not run the completion here (instead appending to a linked list) to avoid:
-                // * recursion through `flush_submissions()` and `flush_completions()`,
-                // * unbounded stack usage, and
-                // * confusing stack traces.
-                self.completed.push(completion);
-            }
-
-            if (completed < cqes.len) break;
-        }
-    }
-
-    fn flush_submissions(self: *IO, wait_nr: u32, timeouts: *usize, etime: *bool) !void {
-        while (true) {
-            const submitted = self.ring.submit_and_wait(wait_nr) catch |err| switch (err) {
+            const submitted = submit_and_wait_timeout(
+                &self.ring,
+                wait_nr,
+                wait_duration_ns,
+            ) catch |err| switch (err) {
                 error.SignalInterrupt => continue,
                 // Wait for some completions and then try again:
                 // See https://github.com/axboe/liburing/issues/281 re: error.SystemResources.
                 // Be careful also that copy_cqes() will flush before entering to wait (it does):
                 // https://github.com/axboe/liburing/commit/35c199c48dfd54ad46b96e386882e7ac341314c5
                 error.CompletionQueueOvercommitted, error.SystemResources => {
-                    try self.flush_completions(1, timeouts, etime);
+                    std.log.warn(
+                        "flush_submissions: completion queue overcommitted.",
+                        .{},
+                    );
+                    try self.flush_completions(1);
                     continue;
                 },
                 else => return err,
@@ -275,6 +179,59 @@ pub const IO = struct {
         }
     }
 
+    /// Copy completions out of the ring and into `self.completed`.
+    fn flush_completions(self: *IO, wait_nr: u32) !void {
+        var cqes: [256]io_uring_cqe = undefined;
+        while (true) {
+            const completed = self.ring.copy_cqes(&cqes, wait_nr) catch |err| switch (err) {
+                error.SignalInterrupt => continue,
+                else => return err,
+            };
+
+            for (cqes[0..completed]) |cqe| {
+                self.ios_in_kernel -= 1;
+
+                const completion: *Completion = @ptrFromInt(cqe.user_data);
+                completion.result = cqe.res;
+
+                // We do not run the completion here (instead appending to a linked list) to avoid:
+                // * recursion through `flush_submissions()` and `flush_completions()`,
+                // * unbounded stack usage, and
+                // * confusing stack traces.
+                self.completed.push(completion);
+            }
+
+            break;
+        }
+    }
+
+    fn run_callback(self: *IO) !void {
+        const completion = self.completed.pop() orelse return;
+
+        var timer = try std.time.Timer.start();
+        defer self.stats.window.time_callbacks.ns += timer.read();
+
+        if (completion.operation == .next_tick) {
+            // next_tick completions are never submitted to the kernel,
+            // so they are not in `awaiting` and bypass the cancel logic.
+            completion.complete();
+            return;
+        }
+
+        assert(!self.awaiting.empty());
+        self.awaiting.remove(completion);
+
+        switch (self.cancel_all_status) {
+            .inactive => completion.complete(),
+            .next => {},
+            .queued => if (completion.operation == .cancel) completion.complete(),
+            .wait => |wait| if (wait.target == completion) {
+                self.cancel_all_status = .next;
+            },
+            .done => unreachable,
+        }
+    }
+
     fn enqueue(self: *IO, completion: *Completion) void {
         switch (self.cancel_all_status) {
             .inactive => {},
@@ -283,9 +240,17 @@ pub const IO = struct {
         }
 
         const sqe = self.ring.get_sqe() catch |err| switch (err) {
-            error.SubmissionQueueFull => {
-                self.unqueued.push(completion);
-                return;
+            error.SubmissionQueueFull => blk: {
+                // FIXME: Currently warns on format.
+                std.log.warn(
+                    "enqueue: submission queue full. flushing. consider resizing IO.init()",
+                    .{},
+                );
+
+                self.flush_submissions(0) catch unreachable;
+                break :blk self.ring.get_sqe() catch |err_inner| switch (err_inner) {
+                    error.SubmissionQueueFull => unreachable,
+                };
             },
         };
         completion.prep(sqe);
@@ -320,9 +285,6 @@ pub const IO = struct {
         defer self.cancel_all_status = .done;
 
         self.cancel_all_status = .next;
-
-        // Discard any operations that haven't started yet.
-        while (self.unqueued.pop()) |_| {}
 
         while (self.awaiting.tail) |target| {
             assert(!self.awaiting.empty());
@@ -370,6 +332,109 @@ pub const IO = struct {
         };
     }
 
+    /// Like IoUring.submit_and_wait, but uses IORING_ENTER_EXT_ARG to pass a timeout
+    /// directly to io_uring_enter, avoiding the need for separate timeout SQEs.
+    fn submit_and_wait_timeout(ring: *IO_Uring, wait_nr: u32, wait_duration_ns: u63) !u32 {
+        const submitted = ring.flush_sq();
+        var flags: u32 = 0;
+
+        // It only makes sense to have a non-zero wait duration if at least one event is required.
+        // Otherwise, it'll return immediately anyway.
+        if (wait_duration_ns > 0) assert(wait_nr > 0);
+
+        if (ring.sq_ring_needs_enter(&flags) or wait_nr > 0) {
+            if (wait_nr > 0 or (ring.flags & linux.IORING_SETUP_IOPOLL) != 0) {
+                flags |= linux.IORING_ENTER_GETEVENTS;
+            }
+
+            if (wait_nr > 0 and wait_duration_ns > 0) {
+                // Use EXT_ARG to pass the timeout directly to io_uring_enter.
+                flags |= linux.IORING_ENTER_EXT_ARG;
+
+                var ts: linux.kernel_timespec = .{
+                    .sec = wait_duration_ns / std.time.ns_per_s,
+                    .nsec = wait_duration_ns % std.time.ns_per_s,
+                };
+
+                var arg = linux.io_uring_getevents_arg{
+                    .sigmask = 0,
+                    .sigmask_sz = linux.NSIG / 8,
+                    .pad = 0,
+                    .ts = @intFromPtr(&ts),
+                };
+
+                return enter_ext(ring, submitted, wait_nr, flags, &arg) catch |err| switch (err) {
+                    // Timeout expired before min_complete CQEs arrived, but the SQEs
+                    // were still submitted to the kernel by flush_sq() above.
+                    error.TimeoutExpired => submitted,
+                    else => err,
+                };
+            } else {
+                return try ring.enter(submitted, wait_nr, flags);
+            }
+        }
+        return submitted;
+    }
+
+    /// Tell the kernel we have submitted SQEs and/or want to wait for CQEs, with
+    /// IORING_ENTER_EXT_ARG.
+    /// Returns the number of SQEs submitted.
+    fn enter_ext(
+        ring: *IO_Uring,
+        to_submit: u32,
+        min_complete: u32,
+        flags: u32,
+        arg: *linux.io_uring_getevents_arg,
+    ) !u32 {
+        assert(ring.fd >= 0);
+        assert((flags & linux.IORING_ENTER_EXT_ARG) != 0);
+
+        // Can't use linux.io_uring_enter because it hardcodes the size of the arg parameter as
+        // NSIG / 8.
+        const res = linux.syscall6(
+            .io_uring_enter,
+            @as(usize, @bitCast(@as(isize, ring.fd))),
+            to_submit,
+            min_complete,
+            flags,
+            @intFromPtr(arg),
+            @sizeOf(linux.io_uring_getevents_arg),
+        );
+
+        switch (linux.E.init(res)) {
+            .SUCCESS => {},
+            // The kernel was unable to allocate memory or ran out of resources for the request.
+            // The application should wait for some completions and try again:
+            .AGAIN => return error.SystemResources,
+            // The SQE `fd` is invalid, or IOSQE_FIXED_FILE was set but no files were registered:
+            .BADF => return error.FileDescriptorInvalid,
+            // The file descriptor is valid, but the ring is not in the right state.
+            // See io_uring_register(2) for how to enable the ring.
+            .BADFD => return error.FileDescriptorInBadState,
+            // The application attempted to overcommit the number of requests it can have pending.
+            // The application should wait for some completions and try again:
+            .BUSY => return error.CompletionQueueOvercommitted,
+            // The SQE is invalid, or valid but the ring was setup with IORING_SETUP_IOPOLL:
+            .INVAL => return error.SubmissionQueueEntryInvalid,
+            // The buffer is outside the process' accessible address space, or IORING_OP_READ_FIXED
+            // or IORING_OP_WRITE_FIXED was specified but no buffers were registered, or the range
+            // described by `addr` and `len` is not within the buffer registered at `buf_index`:
+            .FAULT => return error.BufferInvalid,
+            .NXIO => return error.RingShuttingDown,
+            // The kernel believes our `self.fd` does not refer to an io_uring instance,
+            // or the opcode is valid but not supported by this kernel (more likely):
+            .OPNOTSUPP => return error.OpcodeNotSupported,
+            // The operation was interrupted by a delivery of a signal before it could complete.
+            // This can happen while waiting for events with IORING_ENTER_GETEVENTS:
+            .INTR => return error.SignalInterrupt,
+            // A timeout was specified in arg, and it has expired.
+            .TIME => return error.TimeoutExpired,
+            else => |errno| return stdx.unexpected_errno("io_uring_enter", errno),
+        }
+
+        return @as(u32, @intCast(res));
+    }
+
     pub const CancelError = error{
         NotRunning,
         NotInterruptable,
@@ -397,6 +462,47 @@ pub const IO = struct {
         };
 
         self.enqueue(options.completion);
+    }
+
+    pub const NextTickSource = enum { lsm, vsr };
+
+    /// Schedule a deferred callback that doesn't involve kernel IO.
+    pub fn next_tick(
+        self: *IO,
+        comptime Context: type,
+        context: Context,
+        comptime callback: fn (
+            context: Context,
+            completion: *Completion,
+            result: NextTickResult,
+        ) void,
+        completion: *Completion,
+        source: NextTickSource,
+    ) void {
+        completion.* = .{
+            .io = self,
+            .context = context,
+            .callback = erase_types(Context, NextTickResult, callback),
+            .operation = .{ .next_tick = .{ .source = source } },
+        };
+        self.completed.push(completion);
+    }
+
+    pub const NextTickResult = void;
+
+    /// Remove all next_tick entries with the given source from the completed queue.
+    pub fn reset_next_tick(self: *IO, source: NextTickSource) void {
+        var old = self.completed;
+        self.completed.reset();
+
+        while (old.pop()) |completion| {
+            if (completion.operation == .next_tick and
+                completion.operation.next_tick.source == source)
+            {
+                continue;
+            }
+            self.completed.push(completion);
+        }
     }
 
     /// This struct holds the data needed for a single io_uring operation.
@@ -482,6 +588,7 @@ pub const IO = struct {
                         op.offset,
                     );
                 },
+                .next_tick => unreachable, // Never submitted to the kernel.
             }
             sqe.user_data = @intFromPtr(completion);
         }
@@ -819,6 +926,10 @@ pub const IO = struct {
                     };
                     completion.callback(completion.context, completion, &result);
                 },
+                .next_tick => {
+                    const result: NextTickResult = {};
+                    completion.callback(completion.context, completion, &result);
+                },
             }
         }
     };
@@ -877,6 +988,9 @@ pub const IO = struct {
             fd: fd_t,
             buffer: []const u8,
             offset: u64,
+        },
+        next_tick: struct {
+            source: NextTickSource,
         },
     };
 
@@ -1267,6 +1381,9 @@ pub const IO = struct {
         completion: *Completion,
         nanoseconds: u63,
     ) void {
+        // Use `next_tick()` if you're looking for a yield.
+        assert(nanoseconds > 0);
+
         completion.* = .{
             .io = self,
             .context = context,
@@ -1277,13 +1394,6 @@ pub const IO = struct {
                 },
             },
         };
-
-        // Special case a zero timeout as a yield.
-        if (nanoseconds == 0) {
-            completion.result = -@as(i32, @intFromEnum(posix.E.TIME));
-            self.completed.push(completion);
-            return;
-        }
 
         self.enqueue(completion);
     }

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -114,6 +114,7 @@ pub const IO = struct {
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
         assert(self.cancel_all_status != .done);
 
+        assert(!self.run_for_ns_active);
         self.run_for_ns_active = true;
         defer self.run_for_ns_active = false;
         defer assert(self.run_for_ns_active);

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -15,7 +15,6 @@ const QueueType = @import("../queue.zig").QueueType;
 const buffer_limit = @import("../io.zig").buffer_limit;
 const DirectIO = @import("../io.zig").DirectIO;
 const DoublyLinkedListType = @import("../list.zig").DoublyLinkedListType;
-const parse_dirty_semver = stdx.parse_dirty_semver;
 const maybe = stdx.maybe;
 
 pub const IO = struct {
@@ -62,14 +61,6 @@ pub const IO = struct {
     run_for_ns_active: bool = false,
 
     pub fn init(entries: u12, flags: u32) !IO {
-        // Detect the linux version to ensure that we support all io_uring ops used.
-        const uts = posix.uname();
-        const version = try parse_dirty_semver(&uts.release);
-        // FIXME: Bump this as required.
-        if (version.order(std.SemanticVersion{ .major = 5, .minor = 5, .patch = 0 }) == .lt) {
-            @panic("Linux kernel 5.5 or greater is required for io_uring OP_ACCEPT");
-        }
-
         errdefer |err| switch (err) {
             error.SystemOutdated => {
                 log.err("io_uring is not available", .{});
@@ -83,7 +74,15 @@ pub const IO = struct {
             else => {},
         };
 
-        return IO{ .ring = try IO_Uring.init(entries, flags) };
+        var ring = try IO_Uring.init(entries, flags);
+        errdefer ring.deinit();
+
+        // IORING_ENTER_EXT_ARG is the newest feature we currently use: it was added in 5.11.
+        if ((ring.features & linux.IORING_FEAT_EXT_ARG) == 0) {
+            @panic("Linux kernel 5.11 or greater is required for IORING_ENTER_EXT_ARG");
+        }
+
+        return IO{ .ring = ring };
     }
 
     pub fn deinit(self: *IO) void {

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -116,6 +116,7 @@ pub const IO = struct {
 
         self.run_for_ns_active = true;
         defer self.run_for_ns_active = false;
+        defer assert(self.run_for_ns_active);
 
         defer self.stats.trace();
 

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -113,10 +113,11 @@ pub const IO = struct {
     /// in the kernel_timespec struct.
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
         assert(self.cancel_all_status != .done);
-        defer self.stats.trace();
 
         self.run_for_ns_active = true;
         defer self.run_for_ns_active = false;
+
+        defer self.stats.trace();
 
         var timer = try std.time.Timer.start();
         defer self.stats.window.time_run_for_ns.ns += timer.read();

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -404,6 +404,10 @@ test "event" {
 }
 
 test "submission queue full" {
+    // This test purposefully overflows the queue, set the log level to error to suppress the
+    // warning from IO.
+    std.testing.log_level = .err;
+
     const ms = 20;
     const count = 10;
 
@@ -447,6 +451,10 @@ test "submission queue full" {
 }
 
 test "tick to wait" {
+    // This test purposefully overflows the queue, set the log level to error to suppress the
+    // warning from IO.
+    std.testing.log_level = .err;
+
     // Use only IO.run() to see if pending IO is actually processed.
 
     try struct {

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -52,12 +52,15 @@ pub const IO = struct {
     }
 
     pub fn run(self: *IO) !void {
+        assert(!self.run_for_ns_active);
+
         return self.flush(.non_blocking);
     }
 
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
         self.run_for_ns_active = true;
         defer self.run_for_ns_active = false;
+        defer assert(self.run_for_ns_active);
 
         defer self.stats.trace();
 

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -58,6 +58,7 @@ pub const IO = struct {
     }
 
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
+        assert(!self.run_for_ns_active);
         self.run_for_ns_active = true;
         defer self.run_for_ns_active = false;
         defer assert(self.run_for_ns_active);

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -16,6 +16,7 @@ pub const IO = struct {
     pub const TCPOptions = common.TCPOptions;
     pub const ListenOptions = common.ListenOptions;
     pub const Stats = common.Stats;
+    pub const NextTickSource = common.NextTickSource;
 
     iocp: os.windows.HANDLE,
     time_os: TimeOS = .{},
@@ -250,6 +251,9 @@ pub const IO = struct {
                 deadline: u64,
             },
             event: Overlapped,
+            next_tick: struct {
+                source: NextTickSource,
+            },
         };
     };
 
@@ -1029,23 +1033,8 @@ pub const IO = struct {
         completion: *Completion,
         nanoseconds: u63,
     ) void {
-        // Special case a zero timeout as a yield.
-        if (nanoseconds == 0) {
-            completion.* = .{
-                .link = .{},
-                .context = @ptrCast(context),
-                .operation = undefined,
-                .callback = struct {
-                    fn on_complete(ctx: Completion.Context) void {
-                        const _context: Context = @ptrCast(@alignCast(ctx.completion.context));
-                        callback(_context, ctx.completion, {});
-                    }
-                }.on_complete,
-            };
-
-            self.completed.push(completion);
-            return;
-        }
+        // Use `next_tick()` if you're looking for a yield.
+        assert(nanoseconds > 0);
 
         self.submit(
             context,
@@ -1061,6 +1050,49 @@ pub const IO = struct {
                 }
             },
         );
+    }
+
+    pub const NextTickResult = void;
+
+    /// Schedule a deferred callback that doesn't involve kernel IO.
+    pub fn next_tick(
+        self: *IO,
+        comptime Context: type,
+        context: Context,
+        comptime callback: fn (
+            context: Context,
+            completion: *Completion,
+            result: NextTickResult,
+        ) void,
+        completion: *Completion,
+        source: NextTickSource,
+    ) void {
+        completion.* = .{
+            .link = .{},
+            .context = @ptrCast(context),
+            .operation = .{ .next_tick = .{ .source = source } },
+            .callback = struct {
+                fn on_complete(ctx: Completion.Context) void {
+                    callback(@ptrCast(@alignCast(ctx.completion.context)), ctx.completion, {});
+                }
+            }.on_complete,
+        };
+        self.completed.push(completion);
+    }
+
+    /// Remove all next_tick entries with the given source from the completed queue.
+    pub fn reset_next_tick(self: *IO, source: NextTickSource) void {
+        var old = self.completed;
+        self.completed.reset();
+
+        while (old.pop()) |completion| {
+            if (completion.operation == .next_tick and
+                completion.operation.next_tick.source == source)
+            {
+                continue;
+            }
+            self.completed.push(completion);
+        }
     }
 
     pub const Event = u1;

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -1090,10 +1090,10 @@ pub const IO = struct {
 
     /// Remove all next_tick entries with the given source from the completed queue.
     pub fn reset_next_tick(self: *IO, source: NextTickSource) void {
-        var old = self.completed;
+        var completed = self.completed;
         self.completed.reset();
 
-        while (old.pop()) |completion| {
+        while (completed.pop()) |completion| {
             if (completion.operation == .next_tick and
                 completion.operation.next_tick.source == source)
             {

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -23,6 +23,7 @@ pub const IO = struct {
     io_pending: usize = 0,
     timeouts: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_timeouts" }),
     completed: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_completed" }),
+    run_for_ns_active: bool = false,
 
     stats: common.Stats = .{},
 
@@ -55,6 +56,9 @@ pub const IO = struct {
     }
 
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
+        self.run_for_ns_active = true;
+        defer self.run_for_ns_active = false;
+
         defer self.stats.trace();
 
         var timer = try std.time.Timer.start();

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -60,8 +60,10 @@ pub const IO = struct {
     pub fn run_for_ns(self: *IO, nanoseconds: u63) !void {
         assert(!self.run_for_ns_active);
         self.run_for_ns_active = true;
-        defer self.run_for_ns_active = false;
-        defer assert(self.run_for_ns_active);
+        defer {
+            assert(self.run_for_ns_active);
+            self.run_for_ns_active = false;
+        }
 
         defer self.stats.trace();
 
@@ -172,7 +174,7 @@ pub const IO = struct {
         var timeouts_iterator = self.timeouts.iterate();
         while (timeouts_iterator.next()) |completion| {
             // Lazily get the current time.
-            const now = current_time orelse self.time_os.time().monotonic().ns;
+            const now = current_time orelse self.time_os.monotonic().ns;
             current_time = now;
 
             // Move the completion to completed if it expired.
@@ -1049,7 +1051,7 @@ pub const IO = struct {
             callback,
             completion,
             .timeout,
-            .{ .deadline = self.time_os.time().monotonic().ns + nanoseconds },
+            .{ .deadline = self.time_os.monotonic().ns + nanoseconds },
             struct {
                 fn do_operation(ctx: Completion.Context, op: anytype) TimeoutError!void {
                     _ = ctx;

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -57,7 +57,7 @@ pub fn MessageBusType(comptime IO: type) type {
         connections_suspended: QueueType(Connection) = QueueType(Connection).init(.{
             .name = null,
         }),
-        resume_receive_completion: IO.Completion = undefined,
+        resume_receive_next_tick: IO.Completion = undefined,
         resume_receive_submitted: bool = false,
 
         /// Map from replica index to the currently active connection for that replica, if any.
@@ -1134,25 +1134,20 @@ pub fn MessageBusType(comptime IO: type) type {
             if (!bus.resume_needed()) return;
 
             bus.resume_receive_submitted = true;
-            bus.io.timeout(
+            bus.io.next_tick(
                 *MessageBus,
                 bus,
                 ready_to_receive_callback,
-                &bus.resume_receive_completion,
-                0, // Zero timeout means next tick.
+                &bus.resume_receive_next_tick,
+                .vsr,
             );
         }
 
         fn ready_to_receive_callback(
             bus: *MessageBus,
-            completion: *IO.Completion,
-            result: IO.TimeoutError!void,
+            _: *IO.Completion,
+            _: IO.NextTickResult,
         ) void {
-            assert(completion == &bus.resume_receive_completion);
-            _ = result catch |e| switch (e) {
-                error.Canceled => unreachable,
-                error.Unexpected => unreachable,
-            };
             assert(bus.resume_receive_submitted);
             bus.resume_receive_submitted = false;
             maybe(bus.connections_suspended.empty());

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -482,7 +482,7 @@ pub fn MessageBusType(comptime IO: type) type {
                 connect_timeout_callback,
                 // We use `recv_completion` for the connection `timeout()` and `connect()` calls
                 &connection.recv_completion,
-                @as(u63, @intCast(ms * std.time.ns_per_ms)),
+                @as(u63, @intCast(@max(ms * std.time.ns_per_ms, 1))),
             );
         }
 

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -458,6 +458,8 @@ pub fn MessageBusType(comptime IO: type) type {
             assert(bus.replicas[replica] == null);
             bus.replicas[replica] = connection;
 
+            comptime assert(constants.connection_delay_min.to_ms() > 0);
+
             const attempts = &bus.replicas_connect_attempts[replica];
             const ms = vsr.exponential_backoff_with_jitter(
                 &bus.prng,
@@ -476,13 +478,14 @@ pub fn MessageBusType(comptime IO: type) type {
             assert(!connection.recv_submitted);
             connection.recv_submitted = true;
 
+            assert(ms > 0);
             bus.io.timeout(
                 *MessageBus,
                 bus,
                 connect_timeout_callback,
                 // We use `recv_completion` for the connection `timeout()` and `connect()` calls
                 &connection.recv_completion,
-                @as(u63, @intCast(@max(ms * std.time.ns_per_ms, 1))),
+                @as(u63, @intCast(ms * std.time.ns_per_ms)),
             );
         }
 

--- a/src/message_bus_fuzz.zig
+++ b/src/message_bus_fuzz.zig
@@ -416,6 +416,7 @@ const IO = struct {
     pub const RecvError = RealIO.RecvError;
     pub const SendError = RealIO.SendError;
     pub const TimeoutError = RealIO.TimeoutError;
+    pub const NextTickSource = RealIO.NextTickSource;
     pub const socket_t = i32;
     pub const fd_t = i32;
     const EventQueue = std.PriorityQueue(Event, void, Event.less_than);
@@ -471,6 +472,7 @@ const IO = struct {
         recv: struct { socket: socket_t, buffer: []u8 },
         send: struct { socket: socket_t, buffer: []const u8 },
         timeout,
+        next_tick,
     };
 
     pub const Completion = struct {
@@ -482,6 +484,7 @@ const IO = struct {
             recv: *const fn (*MessageBus, *Completion, RecvError!usize) void,
             send: *const fn (*MessageBus, *Completion, SendError!usize) void,
             timeout: *const fn (*MessageBus, *Completion, TimeoutError!void) void,
+            next_tick: *const fn (*MessageBus, *Completion, NextTickResult) void,
         },
         operation: Operation,
     };
@@ -726,6 +729,9 @@ const IO = struct {
                 const result: TimeoutError!void = {};
                 completion.callback.timeout(completion.context, completion, result);
             },
+            .next_tick => {
+                completion.callback.next_tick(completion.context, completion, {});
+            },
         }
         return .done;
     }
@@ -802,7 +808,7 @@ const IO = struct {
             switch (event.completion.operation) {
                 inline .accept, .connect, .recv, .send => |data| assert(data.socket != fd),
                 .close => |data| assert(data.fd != fd),
-                .timeout => {},
+                .timeout, .next_tick => {},
             }
         }
 
@@ -918,6 +924,28 @@ const IO = struct {
         io.events.add(.{
             .completion = completion,
             .ready_at = io.tick_instant().add(.{ .ns = (nanoseconds -| jitter_mean) + jitter }),
+        }) catch @panic("OOM");
+    }
+
+    pub const NextTickResult = void;
+
+    pub fn next_tick(
+        io: *IO,
+        comptime Context: type,
+        context: Context,
+        comptime callback: fn (Context, *Completion, NextTickResult) void,
+        completion: *Completion,
+        source: NextTickSource,
+    ) void {
+        _ = source;
+        completion.* = .{
+            .context = context,
+            .callback = .{ .next_tick = callback },
+            .operation = .next_tick,
+        };
+        io.events.add(.{
+            .completion = completion,
+            .ready_at = io.tick_instant(),
         }) catch @panic("OOM");
     }
 

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -597,67 +597,6 @@ pub fn update(base: anytype, diff: anytype) @TypeOf(base) {
     return updated;
 }
 
-// std.SemanticVersion requires there be no extra characters after the
-// major/minor/patch numbers. But when we try to parse `uname
-// --kernel-release` (note: while Linux doesn't follow semantic
-// versioning, it doesn't violate it either), some distributions have
-// extra characters, such as this Fedora one: 6.3.8-100.fc37.x86_64, and
-// this WSL one has more than three dots:
-// 5.15.90.1-microsoft-standard-WSL2.
-pub fn parse_dirty_semver(dirty_release: []const u8) !std.SemanticVersion {
-    const release = blk: {
-        var last_valid_version_character_index: usize = 0;
-        var dots_found: u8 = 0;
-        for (dirty_release) |c| {
-            if (c == '.') dots_found += 1;
-            if (dots_found == 3) {
-                break;
-            }
-
-            if (c == '.' or (c >= '0' and c <= '9')) {
-                last_valid_version_character_index += 1;
-                continue;
-            }
-
-            break;
-        }
-
-        break :blk dirty_release[0..last_valid_version_character_index];
-    };
-
-    return std.SemanticVersion.parse(release);
-}
-
-test "stdx.zig: parse_dirty_semver" {
-    const SemverTestCase = struct {
-        dirty_release: []const u8,
-        expected_version: std.SemanticVersion,
-    };
-
-    const cases = &[_]SemverTestCase{
-        .{
-            .dirty_release = "1.2.3",
-            .expected_version = std.SemanticVersion{ .major = 1, .minor = 2, .patch = 3 },
-        },
-        .{
-            .dirty_release = "1001.843.909",
-            .expected_version = std.SemanticVersion{ .major = 1001, .minor = 843, .patch = 909 },
-        },
-        .{
-            .dirty_release = "6.3.8-100.fc37.x86_64",
-            .expected_version = std.SemanticVersion{ .major = 6, .minor = 3, .patch = 8 },
-        },
-        .{
-            .dirty_release = "5.15.90.1-microsoft-standard-WSL2",
-            .expected_version = std.SemanticVersion{ .major = 5, .minor = 15, .patch = 90 },
-        },
-    };
-    for (cases) |case| {
-        const version = try parse_dirty_semver(case.dirty_release);
-        try std.testing.expectEqual(case.expected_version, version);
-    }
-}
-
 // TODO(zig): std doesn't have the statfs / fstatfs syscalls to get the type of a filesystem.
 // Once those are available, this can be removed.
 // The `statfs` definition used by the Linux kernel, and the magic number for tmpfs, from

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -5,7 +5,6 @@ const log = std.log.scoped(.storage);
 
 const vsr = @import("vsr.zig");
 const stdx = vsr.stdx;
-const QueueType = vsr.queue.QueueType;
 const constants = vsr.constants;
 const Tracer = vsr.trace.Tracer;
 
@@ -86,24 +85,14 @@ pub fn StorageType(comptime IO: type) type {
             start: ?stdx.Instant,
         };
 
-        pub const NextTick = struct {
-            link: QueueType(NextTick).Link = .{},
-            source: NextTickSource,
-            callback: *const fn (next_tick: *NextTick) void,
-        };
+        pub const NextTick = IO.Completion;
 
-        pub const NextTickSource = enum { lsm, vsr };
+        pub const NextTickSource = IO.NextTickSource;
 
         io: *IO,
         tracer: *Tracer,
         dir_fd: IO.fd_t,
         fd: IO.fd_t,
-
-        next_tick_queue: QueueType(NextTick) = QueueType(NextTick).init(.{
-            .name = "storage_next_tick",
-        }),
-        next_tick_completion_scheduled: bool = false,
-        next_tick_completion: IO.Completion = undefined,
 
         pub fn init(io: *IO, tracer: *Tracer, options: struct {
             path: []const u8,
@@ -137,7 +126,6 @@ pub fn StorageType(comptime IO: type) type {
         }
 
         pub fn deinit(storage: *Storage) void {
-            assert(storage.next_tick_queue.empty());
             assert(storage.fd != IO.INVALID_FILE);
             assert(storage.dir_fd != IO.INVALID_FILE);
 
@@ -158,58 +146,33 @@ pub fn StorageType(comptime IO: type) type {
         pub fn on_next_tick(
             storage: *Storage,
             source: NextTickSource,
-            callback: *const fn (next_tick: *Storage.NextTick) void,
+            callback: *const fn (*Storage.NextTick) void,
             next_tick: *Storage.NextTick,
         ) void {
-            next_tick.* = .{
-                .source = source,
-                .callback = callback,
-            };
-
-            storage.next_tick_queue.push(next_tick);
-
-            if (!storage.next_tick_completion_scheduled) {
-                storage.next_tick_completion_scheduled = true;
-                storage.io.timeout(
-                    *Storage,
-                    storage,
-                    timeout_callback,
-                    &storage.next_tick_completion,
-                    0, // 0ns timeout means to resolve as soon as possible - like a yield
-                );
-            }
+            // Do a bit of pointer trickery to keep the grid on_next_tick interface the same for
+            // now.
+            storage.io.next_tick(
+                ?*anyopaque,
+                @ptrCast(@constCast(callback)),
+                struct {
+                    fn adapter(
+                        ctx: ?*anyopaque,
+                        completion: *IO.Completion,
+                        _: IO.NextTickResult,
+                    ) void {
+                        const callback_original: *const fn (*NextTick) void = @ptrCast(
+                            @alignCast(ctx.?),
+                        );
+                        callback_original(completion);
+                    }
+                }.adapter,
+                next_tick,
+                source,
+            );
         }
 
         pub fn reset_next_tick_lsm(storage: *Storage) void {
-            var next_tick_iterator = storage.next_tick_queue;
-            storage.next_tick_queue.reset();
-
-            while (next_tick_iterator.pop()) |next_tick| {
-                if (next_tick.source != .lsm) storage.next_tick_queue.push(next_tick);
-            }
-        }
-
-        fn timeout_callback(
-            storage: *Storage,
-            completion: *IO.Completion,
-            result: IO.TimeoutError!void,
-        ) void {
-            assert(completion == &storage.next_tick_completion);
-            _ = result catch |e| switch (e) {
-                error.Canceled => unreachable,
-                error.Unexpected => unreachable,
-            };
-
-            // Reset the scheduled flag after processing all tick entries
-            assert(storage.next_tick_completion_scheduled);
-            defer {
-                assert(storage.next_tick_completion_scheduled);
-                storage.next_tick_completion_scheduled = false;
-            }
-
-            while (storage.next_tick_queue.pop()) |next_tick| {
-                next_tick.callback(next_tick);
-            }
+            storage.io.reset_next_tick(.lsm);
         }
 
         pub fn read_sectors(

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -627,6 +627,9 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
 
             reformat.format() catch |err| fatal(.correctness, "reformat: {}", .{err});
 
+            vsr.format(Storage, cluster.allocator, reformat.storage, reformat.options) catch
+                unreachable;
+
             reformat.deinit(cluster.allocator);
             cluster.replica_reformats[replica_index] = null;
             cluster.replica_health[replica_index] = .down;

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -627,9 +627,6 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
 
             reformat.format() catch |err| fatal(.correctness, "reformat: {}", .{err});
 
-            vsr.format(Storage, cluster.allocator, reformat.storage, reformat.options) catch
-                unreachable;
-
             reformat.deinit(cluster.allocator);
             cluster.replica_reformats[replica_index] = null;
             cluster.replica_health[replica_index] = .down;

--- a/src/testing/io.zig
+++ b/src/testing/io.zig
@@ -299,10 +299,10 @@ pub const IO = struct {
 
     /// Remove all next_tick entries with the given source from the completed queue.
     pub fn reset_next_tick(self: *IO, source: NextTickSource) void {
-        var old = self.completed;
+        var completed = self.completed;
         self.completed.reset();
 
-        while (old.pop()) |completion| {
+        while (completed.pop()) |completion| {
             if (completion.operation == .next_tick and
                 completion.operation.next_tick.source == source)
             {

--- a/src/testing/io.zig
+++ b/src/testing/io.zig
@@ -5,6 +5,7 @@ const assert = std.debug.assert;
 
 const stdx = @import("stdx");
 const constants = @import("../constants.zig");
+const common = @import("../io/common.zig");
 const QueueType = @import("../queue.zig").QueueType;
 const buffer_limit = @import("../io.zig").buffer_limit;
 const Ratio = stdx.PRNG.Ratio;
@@ -12,6 +13,7 @@ const Ratio = stdx.PRNG.Ratio;
 /// A very simple mock IO implementation that only implements what is needed to test Storage.
 pub const IO = struct {
     pub const fd_t = u32;
+    pub const NextTickSource = common.NextTickSource;
 
     pub const File = struct {
         buffer: []u8,
@@ -86,6 +88,9 @@ pub const IO = struct {
         },
         fsync: struct {
             fd: fd_t,
+        },
+        next_tick: struct {
+            source: NextTickSource,
         },
     };
 
@@ -262,6 +267,49 @@ pub const IO = struct {
                 fn do_operation(_: *IO, _: anytype) FsyncError!void {}
             },
         );
+    }
+
+    pub const NextTickResult = void;
+
+    /// Schedule a deferred callback that doesn't involve kernel IO.
+    pub fn next_tick(
+        self: *IO,
+        comptime Context: type,
+        context: Context,
+        comptime callback: fn (
+            context: Context,
+            completion: *Completion,
+            result: NextTickResult,
+        ) void,
+        completion: *Completion,
+        source: NextTickSource,
+    ) void {
+        completion.* = .{
+            .link = .{},
+            .context = context,
+            .operation = .{ .next_tick = .{ .source = source } },
+            .callback = struct {
+                fn on_complete(_: *IO, _completion: *Completion) void {
+                    callback(@ptrCast(@alignCast(_completion.context)), _completion, {});
+                }
+            }.on_complete,
+        };
+        self.completed.push(completion);
+    }
+
+    /// Remove all next_tick entries with the given source from the completed queue.
+    pub fn reset_next_tick(self: *IO, source: NextTickSource) void {
+        var old = self.completed;
+        self.completed.reset();
+
+        while (old.pop()) |completion| {
+            if (completion.operation == .next_tick and
+                completion.operation.next_tick.source == source)
+            {
+                continue;
+            }
+            self.completed.push(completion);
+        }
     }
 
     pub fn aof_blocking_write_all(self: *IO, fd: fd_t, source: []const u8) posix.WriteError!void {

--- a/src/testing/vortex/faulty_network.zig
+++ b/src/testing/vortex/faulty_network.zig
@@ -152,6 +152,7 @@ const Pipe = struct {
         }
 
         if (pipe.connection.network.faults.delay) |delay| {
+            assert(delay.time_ms > 0);
             assert(delay.jitter_ms <= delay.time_ms);
             const jitter_size = pipe.connection.network.prng.int_inclusive(
                 u32,
@@ -163,6 +164,8 @@ const Pipe = struct {
                 u63,
                 @intCast(@as(i32, @intCast(delay.time_ms)) + jitter_diff_ms),
             ) * std.time.ns_per_ms;
+            assert(timeout_duration_ns > 0);
+
             log.debug("delaying {} ({d},{d})", .{
                 std.fmt.fmtDuration(timeout_duration_ns),
                 pipe.connection.replica_index,
@@ -176,7 +179,7 @@ const Pipe = struct {
                 pipe,
                 timeout_callback,
                 &pipe.send_completion,
-                @max(timeout_duration_ns, 1),
+                timeout_duration_ns,
             );
         } else {
             pipe.send();

--- a/src/testing/vortex/faulty_network.zig
+++ b/src/testing/vortex/faulty_network.zig
@@ -176,7 +176,7 @@ const Pipe = struct {
                 pipe,
                 timeout_callback,
                 &pipe.send_completion,
-                timeout_duration_ns,
+                @max(timeout_duration_ns, 1),
             );
         } else {
             pipe.send();

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -535,7 +535,7 @@ const Benchmark = struct {
             &b.client_timeouts[client_index],
             create_transfers_next,
             &b.client_timeouts[client_index].completion,
-            @intCast(b.transfer_batch_delay.ns),
+            @intCast(@max(b.transfer_batch_delay.ns, 1)),
         );
     }
 

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -528,15 +528,19 @@ const Benchmark = struct {
             });
         }
 
-        b.client_timeouts[client_index] = .{ .benchmark = b, .client_index = client_index };
-        b.clients_busy.set(client_index);
-        b.io.timeout(
-            *Timeout,
-            &b.client_timeouts[client_index],
-            create_transfers_next,
-            &b.client_timeouts[client_index].completion,
-            @intCast(@max(b.transfer_batch_delay.ns, 1)),
-        );
+        if (b.transfer_batch_delay.ns == 0) {
+            b.create_transfers(client_index);
+        } else {
+            b.client_timeouts[client_index] = .{ .benchmark = b, .client_index = client_index };
+            b.clients_busy.set(client_index);
+            b.io.timeout(
+                *Timeout,
+                &b.client_timeouts[client_index],
+                create_transfers_next,
+                &b.client_timeouts[client_index].completion,
+                @intCast(b.transfer_batch_delay.ns),
+            );
+        }
     }
 
     fn create_transfers_next(

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -87,7 +87,11 @@ pub fn main() !void {
 
     // Try and init IO early, before a file has even been created, so if it fails (eg, io_uring
     // is not available) there won't be a dangling file.
-    var io = try IO.init(128, 0);
+    const io_entries: u12 = switch (command) {
+        .format, .recover => 2048,
+        else => 128,
+    };
+    var io = try IO.init(io_entries, 0);
     defer io.deinit();
 
     var time_os: TimeOS = .{};

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -88,6 +88,8 @@ pub fn main() !void {
     // Try and init IO early, before a file has even been created, so if it fails (eg, io_uring
     // is not available) there won't be a dangling file.
     const io_entries: u12 = switch (command) {
+        // In format, all writes are issued in parallel with no backpressue. It's nice and simple,
+        // but means a larger loop size is needed to avoid a warning.
         .format, .recover => 2048,
         else => 128,
     };

--- a/src/time.zig
+++ b/src/time.zig
@@ -52,16 +52,19 @@ pub const TimeOS = struct {
         return .{
             .context = self,
             .vtable = &.{
-                .monotonic = monotonic,
+                .monotonic = vtable_monotonic,
                 .realtime = realtime,
                 .tick = tick,
             },
         };
     }
 
-    fn monotonic(context: *anyopaque) u64 {
+    fn vtable_monotonic(context: *anyopaque) u64 {
         const self: *TimeOS = @ptrCast(@alignCast(context));
+        return self.monotonic().ns;
+    }
 
+    pub fn monotonic(self: *TimeOS) Instant {
         const m = blk: {
             if (is_windows) break :blk monotonic_windows();
             if (is_darwin) break :blk monotonic_darwin();
@@ -72,7 +75,7 @@ pub const TimeOS = struct {
         // "Oops!...I Did It Again"
         if (m < self.monotonic_guard) @panic("a hardware/kernel bug regressed the monotonic clock");
         self.monotonic_guard = m;
-        return m;
+        return .{ .ns = m };
     }
 
     fn monotonic_windows() u64 {

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -170,6 +170,7 @@ pub const Event = union(enum) {
     loop_run_for_ns,
     loop_tick,
     loop_callbacks,
+    loop_kernel,
 
     pub const Tag = std.meta.Tag(Event);
 
@@ -249,6 +250,7 @@ pub const EventTiming = union(Event.Tag) {
     loop_run_for_ns,
     loop_tick,
     loop_callbacks,
+    loop_kernel,
 
     pub const slot_limits = std.enums.EnumArray(Event.Tag, u32).init(.{
         .replica_commit = enum_count(CommitStage.Tag),
@@ -276,6 +278,7 @@ pub const EventTiming = union(Event.Tag) {
         .loop_run_for_ns = 1,
         .loop_tick = 1,
         .loop_callbacks = 1,
+        .loop_kernel = 1,
     });
 
     pub const slot_bases = array: {
@@ -413,6 +416,7 @@ pub const EventTracing = union(Event.Tag) {
     loop_run_for_ns,
     loop_tick,
     loop_callbacks,
+    loop_kernel,
 
     pub const stack_limits = std.enums.EnumArray(Event.Tag, u32).init(.{
         .replica_commit = 1,
@@ -440,6 +444,7 @@ pub const EventTracing = union(Event.Tag) {
         .loop_run_for_ns = 1,
         .loop_tick = 1,
         .loop_callbacks = 1,
+        .loop_kernel = 1,
     });
 
     pub const stack_bases = array: {
@@ -522,7 +527,11 @@ pub const EventTracing = union(Event.Tag) {
     // captured, but no per trace logs or JSON will be emitted.
     pub fn aggregate_only(event: *const EventTracing) bool {
         return switch (event.*) {
-            .loop_run_for_ns, .loop_tick, .loop_callbacks => true,
+            .loop_run_for_ns,
+            .loop_tick,
+            .loop_callbacks,
+            .loop_kernel,
+            => true,
             else => false,
         };
     }
@@ -568,6 +577,8 @@ pub const EventMetric = union(enum) {
     compaction_values_physical: struct { tree: TreeEnum },
     compaction_values_logical: struct { tree: TreeEnum },
 
+    loop_syscalls,
+
     pub const slot_limits = std.enums.EnumArray(Tag, u32).init(.{
         .table_count_visible = enum_count(TreeEnum),
         .table_count_visible_max = enum_count(TreeEnum),
@@ -605,6 +616,7 @@ pub const EventMetric = union(enum) {
         .message_bus_connections_max = 1,
         .compaction_values_physical = enum_count(TreeEnum),
         .compaction_values_logical = enum_count(TreeEnum),
+        .loop_syscalls = 1,
     });
 
     pub const slot_bases = array: {
@@ -823,6 +835,7 @@ test "EventTiming slot doesn't have collisions" {
             .loop_run_for_ns => .loop_run_for_ns,
             .loop_tick => .loop_tick,
             .loop_callbacks => .loop_callbacks,
+            .loop_kernel => .loop_kernel,
         };
         try stacks.append(allocator, event.slot());
     }

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -150,6 +150,7 @@ pub const Event = union(enum) {
     loop_run_for_ns,
     loop_tick,
     loop_callbacks,
+    loop_kernel,
 
     pub const Tag = std.meta.Tag(Event);
 
@@ -229,6 +230,7 @@ pub const EventTiming = union(Event.Tag) {
     loop_run_for_ns,
     loop_tick,
     loop_callbacks,
+    loop_kernel,
 
     pub const slot_limits = std.enums.EnumArray(Event.Tag, u32).init(.{
         .replica_commit = enum_count(CommitStage.Tag),
@@ -256,6 +258,7 @@ pub const EventTiming = union(Event.Tag) {
         .loop_run_for_ns = 1,
         .loop_tick = 1,
         .loop_callbacks = 1,
+        .loop_kernel = 1,
     });
 
     pub const slot_bases = array: {
@@ -393,6 +396,7 @@ pub const EventTracing = union(Event.Tag) {
     loop_run_for_ns,
     loop_tick,
     loop_callbacks,
+    loop_kernel,
 
     pub const stack_limits = std.enums.EnumArray(Event.Tag, u32).init(.{
         .replica_commit = 1,
@@ -420,6 +424,7 @@ pub const EventTracing = union(Event.Tag) {
         .loop_run_for_ns = 1,
         .loop_tick = 1,
         .loop_callbacks = 1,
+        .loop_kernel = 1,
     });
 
     pub const stack_bases = array: {
@@ -502,7 +507,11 @@ pub const EventTracing = union(Event.Tag) {
     // captured, but no per trace logs or JSON will be emitted.
     pub fn aggregate_only(event: *const EventTracing) bool {
         return switch (event.*) {
-            .loop_run_for_ns, .loop_tick, .loop_callbacks => true,
+            .loop_run_for_ns,
+            .loop_tick,
+            .loop_callbacks,
+            .loop_kernel,
+            => true,
             else => false,
         };
     }
@@ -543,6 +552,8 @@ pub const EventMetric = union(enum) {
     compaction_values_physical: struct { tree: TreeEnum },
     compaction_values_logical: struct { tree: TreeEnum },
 
+    loop_syscalls,
+
     pub const slot_limits = std.enums.EnumArray(Tag, u32).init(.{
         .table_count_visible = enum_count(TreeEnum),
         .table_count_visible_max = enum_count(TreeEnum),
@@ -575,6 +586,7 @@ pub const EventMetric = union(enum) {
         .message_bus_connections_max = 1,
         .compaction_values_physical = enum_count(TreeEnum),
         .compaction_values_logical = enum_count(TreeEnum),
+        .loop_syscalls = 1,
     });
 
     pub const slot_bases = array: {
@@ -774,6 +786,7 @@ test "EventTiming slot doesn't have collisions" {
             .loop_run_for_ns => .loop_run_for_ns,
             .loop_tick => .loop_tick,
             .loop_callbacks => .loop_callbacks,
+            .loop_kernel => .loop_kernel,
         };
         try stacks.append(allocator, event.slot());
     }


### PR DESCRIPTION
This PR reworks the Linux event loop, primarily by doing 3 things:

- switching to use `IORING_ENTER_EXT_ARG` (requires Kernel 5.11+ - now checked with feature detection - not probing - instead of uname) to directly embed a timeout with `io_uring_enter`,
- making `next_tick` a top level IO feature and,
- reentering the kernel after each callback.

The first simplifies the `run_for_ns` (and `flush`'ing) logic a great deal: a separate timeout no longer needs to be tracked, and there's no need for a previous workaround to avoid getting deadlocked due to a kernel bug.

The second and third combined give an 8% throughput boost, by actually pipelining IO and CPU work. Events are submitted to the kernel after each completion's callback finishes, as a balance between all-the-syscalls (flushing after each operation) and no pipelining (flushing only after all callbacks have finished executing).

There are some other nice minor tweaks too:
- the case in #3530 is handled,
- we are more accurate in `run_for_ns`: by only executing callbacks and blocking to our target time,
- no more `unqueued` - rather do an inline flush in the rare case the SQ is full, and lastly,
- `timeout(0)` is banned!

<details>
  <summary>Benchmarks</summary>

## tmpfs
### Main
```
1222 batches in 13.90 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 719174 tx/s

1222 batches in 13.97 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 715643 tx/s
```

### Branch
```
1222 batches in 13.49 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 741148 tx/s

1222 batches in 13.43 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 744325 tx/s
```

## NVMe
### Main
```
1222 batches in 23.63 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 423151 tx/s

1222 batches in 23.75 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 421076 tx/s
```

### Branch
```
1222 batches in 21.73 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 460245 tx/s

1222 batches in 21.76 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 459625 tx/s
```
</details>

