### PR TITLE
Client: Wrap random on overflow, increment timestamp

### DIFF
--- a/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs
+++ b/src/clients/dotnet/TigerBeetle/UInt128Extensions.cs
@@ -151,7 +151,7 @@ public static class ID
             randomHi = BitConverter.ToUInt16(lastRandom.Slice(8));
 
             // Increment the u80 stored in lastRandom using a u64 increment then u16 increment.
-            // Throws an exception if the entire u80 represented with both overflows.
+            // If both overflow, increment timestamp too.
             // We rely on unsigned arithmetic wrapping on overflow by detecting for zero after inc.
             // Unsigned types wrap by default but can be overridden by compiler flag so be explicit.
             unchecked
@@ -162,7 +162,12 @@ public static class ID
                     randomHi += 1;
                     if (randomHi == 0)
                     {
-                        throw new OverflowException("Random bits overflow on monotonic increment");
+                        timestamp += 1;
+                        idLastTimestamp = timestamp;
+                        if (timestamp == 1 << 48)
+                        {
+                            throw new OverflowException("Timestamp bits overflow on monotonic increment");
+                        }
                     }
                 }
             }

--- a/src/clients/go/uint128.go
+++ b/src/clients/go/uint128.go
@@ -121,6 +121,9 @@ var idMutex sync.Mutex
 // Generates a Universally Unique and Sortable Identifier based on https://github.com/ulid/spec.
 // Uint128 returned are guaranteed to be monotonically increasing when interpreted as little-endian.
 // `ID()` is safe to call from multiple goroutines with monotonicity being sequentially consistent.
+//
+// Panics if it is unable to generated random bytes.
+// Panics if the timestamp is outside of a reasonable bounds.
 func ID() Uint128 {
 	timestamp := time.Now().UnixMilli()
 

--- a/src/clients/go/uint128.go
+++ b/src/clients/go/uint128.go
@@ -142,14 +142,18 @@ func ID() Uint128 {
 	randomLo := binary.LittleEndian.Uint64(idLastRandom[:8])
 	randomHi := binary.LittleEndian.Uint16(idLastRandom[8:])
 
-	// Increment the random bits as a uint80 together, checking for overflow.
-	// Go defines unsigned arithmetic to wrap around on overflow by default so check for zero.
+	// Increment the random bits as a uint80 together.
+	// If the random bits wrap, increment the timestamp.
 	randomLo += 1
 	if randomLo == 0 {
 		randomHi += 1
 		if randomHi == 0 {
-			idMutex.Unlock()
-			panic("random bits overflow on monotonic increment")
+			timestamp += 1
+			idLastTimestamp = timestamp
+
+			if timestamp == 1<<48 {
+				panic("timestamp overflow")
+			}
 		}
 	}
 

--- a/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
@@ -209,13 +209,17 @@ public enum UInt128 {
             randomHi = random.getShort();
 
             // Increment the u80 stored in idLastRandom using a u64 increment then u16 increment.
-            // Throws an exception if the entire u80 represented with both overflows.
+            // If both overflow, increment timestamp too.
             // In Java, all arithmetic wraps around on overflow by default so check for zero.
             randomLo += 1;
             if (randomLo == 0) {
                 randomHi += 1;
                 if (randomHi == 0) {
-                    throw new ArithmeticException("Random bits overflow on monotonic increment");
+                    timestamp += 1;
+                    idLastTimestamp = timestamp;
+                    if (timestamp == 1 << 48) {
+                        throw new ArithmeticException("Timestamp overflow on monotonic increment");
+                    }
                 }
             }
 

--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -207,15 +207,20 @@ export function id(): bigint {
   // Increment the u80 in idLastBuffer using carry arithmetic on u32s (as JS doesn't have fast u64).
   const littleEndian = true
   const randomLo32 = idLastBuffer.getUint32(0, littleEndian) + 1
-  const randomHi32 = idLastBuffer.getUint32(4, littleEndian) + (randomLo32 > 0xFFFFFFFF ? 1 : 0)
-  const randomHi16 = idLastBuffer.getUint16(8, littleEndian) + (randomHi32 > 0xFFFFFFFF ? 1 : 0)
+  const randomHi32 = idLastBuffer.getUint32(4, littleEndian) + (randomLo32 > 0xFFFF_FFFF ? 1 : 0)
+  const randomHi16 = idLastBuffer.getUint16(8, littleEndian) + (randomHi32 > 0xFFFF_FFFF ? 1 : 0)
   if (randomHi16 > 0xFFFF) {
-    throw new Error('random bits overflow on monotonic increment')
+    timestamp += 1
+    idLastTimestamp = timestamp
+
+    if (timestamp === 0x1_0000_0000_0000) {
+        throw new Error('timestamp overflow on monotonic increment')
+    }
   }
 
   // Store the incremented random monotonic and the timestamp into the buffer.
-  idLastBuffer.setUint32(0, randomLo32 & 0xFFFFFFFF, littleEndian)
-  idLastBuffer.setUint32(4, randomHi32 & 0xFFFFFFFF, littleEndian)
+  idLastBuffer.setUint32(0, randomLo32 & 0xFFFF_FFFF, littleEndian)
+  idLastBuffer.setUint32(4, randomHi32 & 0xFFFF_FFFF, littleEndian)
   idLastBuffer.setUint16(8, randomHi16, littleEndian) // No need to mask since checked above.
   idLastBuffer.setUint16(10, timestamp & 0xFFFF, littleEndian) // timestamp lo.
   idLastBuffer.setUint32(12, (timestamp / 0x10000) | 0, littleEndian) // timestamp hi.

--- a/src/clients/python/src/tigerbeetle/client.py
+++ b/src/clients/python/src/tigerbeetle/client.py
@@ -59,9 +59,14 @@ class _IDGenerator:
 
     Keeps a monotonically increasing millisecond timestamp between calls to `.generate()`.
     """
+    _last_time_ms: int
+    _last_random: int
+
     def __init__(self) -> None:
         self._last_time_ms = time.time_ns() // (1000 * 1000)
         self._last_random = int.from_bytes(os.urandom(10), 'little')
+        assert self._last_time_ms < (1 << 48)
+        assert self._last_random < (1 << 80)
 
     def generate(self) -> int:
         time_ms = time.time_ns() // (1000 * 1000)
@@ -75,7 +80,11 @@ class _IDGenerator:
 
         self._last_random += 1
         if self._last_random == 2 ** 80:
-            raise Exception('random bits overflow on monotonic increment')
+            time_ms += 1
+            self._last_time_ms = time_ms
+            self._last_random = 0
+            if time_ms == 1 << 48:
+                raise Exception('Timestamp bits overflow on monotonic increment')
 
         return (time_ms << 80) | self._last_random
 


### PR DESCRIPTION
When generating a TigerBeetle time-based id:
- If the random bits overflow when we increment them, increment the timestamp.
- If the timestamp overflows, panic/throw an error.

Previously clients (except Rust) would panic/throw if the random bits overflow. But that can happen easily in the (admittedly unlikely) case that our initial random number is near `2 ** 80`. (The Rust client already handled random-overflow gracefully.)

NB: Timestamp "overflows" at _48 bits_, since that is how many bits of timestamp are in the TigerBeetle id. (Clients shouldn't ever hit this overflow, unless the client's clock is really broken!)