### PR TITLE
lsm: back cache_map writes with a slot index into table_mutable

### DIFF
--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -8,21 +8,15 @@ const maybe = stdx.maybe;
 const SetAssociativeCacheType = @import("set_associative_cache.zig").SetAssociativeCacheType;
 const ScopeCloseMode = @import("tree.zig").ScopeCloseMode;
 
-/// A CacheMap is a hybrid between our SetAssociativeCache and a HashMap (stash). The
-/// SetAssociativeCache sits on top and absorbs the majority of get / put requests. Below that,
-/// lives a HashMap. Should an insert() cause an eviction (which can happen either because the Key
-/// is the same, or because our Way is full), the evicted value is caught and put in the stash.
+/// A CacheMap is a SetAssociativeCache over an optional `write_index` and a HashMap `stash`.
 ///
-/// This allows for a potentially huge cache, with all the advantages of CLOCK Nth-Chance, while
-/// still being able to give hard guarantees that values will be present. The stash will often be
-/// significantly smaller, as the amount of values we're required to guarantee is less than what
-/// we'd like to optimistically keep in memory.
+/// `write_index` maps a primary key to a slot in the parent tree's `table_mutable.values`,
+/// so slot=some upserts don't duplicate the Value bytes between the mutable table and the
+/// stash. When `Options.write_index_value_count_max == 0` the cache_map falls back to the
+/// historical single-stash layout.
 ///
-/// Within our LSM, the CacheMap is the backing for the combined Groove prefetch + cache. The cache
-/// part fills the use case of an object cache, while the stash ensures that prefetched values
-/// are available in memory during their respective commit.
-///
-/// Cache invalidation for the stash is handled by `compact`.
+/// Lookups walk: cache -> write_index -> stash. `compact()` clears both write_index and
+/// stash at the bar boundary, before the tree's mutable->immutable swap.
 pub fn CacheMapType(
     comptime Key: type,
     comptime Value: type,
@@ -59,23 +53,46 @@ pub fn CacheMapType(
             map_load_percentage_max,
         );
 
+        // Maps a primary Key to a slot in `values_backing.*` (the parent tree's
+        // `table_mutable.values`). Only allocated when `Options.write_index_value_count_max > 0`.
+        pub const WriteIndex = std.AutoHashMapUnmanaged(Key, u32);
+
         pub const Options = struct {
             cache_value_count_max: u32,
+            // The maximum number of slot=some entries the `write_index` must hold. Set to 0
+            // to disable the write_index entirely (in which case the cache_map behaves like
+            // its pre-optimization self: a single stash holding full Values).
+            //
+            // The intended sizing for write_index_value_count_max is the worst-case number
+            // of `tree.put` operations that can land in `tree.table_mutable` between two
+            // bar boundaries, which equals `lsm_compaction_ops * batch_value_count_limit`.
+            write_index_value_count_max: u32 = 0,
+            // The maximum number of values the `stash` must hold. With `write_index`
+            // disabled this is `lsm_compaction_ops * (batch + prefetch)` (the historical
+            // bound). With `write_index` enabled, the slot=some population moves into
+            // `write_index`, so the stash only needs `lsm_compaction_ops * prefetch`.
             stash_value_count_max: u32,
             scope_value_count_max: u32,
             name: []const u8,
         };
 
-        // The hierarchy for lookups is cache (if present) -> stash -> immutable table -> lsm.
-        // Lower levels _may_ have stale values, provided the correct value exists
-        // in one of the levels above.
-        // Evictions from the cache first flow into stash, with `.compact()` clearing it.
-        // When cache is null, the stash mirrors the mutable table.
         cache: ?Cache,
+        // The slot-pointer index. Empty (zero capacity) when
+        // `Options.write_index_value_count_max == 0`.
+        write_index: WriteIndex,
         stash: Map,
 
+        // Stable pointer to the slice header backing `write_index`'s slot indices. Set via
+        // `attach_values_backing` after the parent tree is initialized. The slice header
+        // (not the slice itself) is what's stable, since `tree.table_mutable.values` gets
+        // `std.mem.swap`'d during `compact`/`absorb`. Always null when write_index is
+        // disabled.
+        values_backing: ?*const []Value,
+
         // Scopes allow you to perform operations on the CacheMap before either persisting or
-        // discarding them.
+        // discarding them. Slot-aware upserts ALSO append to the rollback log (we save the
+        // pre-scope value, not the slot, since the rebuild path reconstructs the slot from
+        // the post-rewind tree state).
         scope_is_active: bool = false,
         scope_rollback_log: std.ArrayListUnmanaged(Value),
 
@@ -84,6 +101,7 @@ pub fn CacheMapType(
         pub fn init(allocator: std.mem.Allocator, options: Options) !CacheMap {
             assert(options.stash_value_count_max > 0);
             maybe(options.cache_value_count_max == 0);
+            maybe(options.write_index_value_count_max == 0);
             maybe(options.scope_value_count_max == 0);
 
             var cache: ?Cache = if (options.cache_value_count_max == 0) null else try Cache.init(
@@ -92,6 +110,15 @@ pub fn CacheMapType(
                 .{ .name = options.name },
             );
             errdefer if (cache) |*cache_unwrapped| cache_unwrapped.deinit(allocator);
+
+            var write_index: WriteIndex = .{};
+            if (options.write_index_value_count_max > 0) {
+                try write_index.ensureTotalCapacity(
+                    allocator,
+                    options.write_index_value_count_max,
+                );
+            }
+            errdefer write_index.deinit(allocator);
 
             var stash: Map = .{};
             try stash.ensureTotalCapacity(allocator, options.stash_value_count_max);
@@ -105,19 +132,47 @@ pub fn CacheMapType(
 
             return CacheMap{
                 .cache = cache,
+                .write_index = write_index,
                 .stash = stash,
+                .values_backing = null,
                 .scope_rollback_log = scope_rollback_log,
                 .options = options,
             };
+        }
+
+        // Attach the slice-header pointer that backs `write_index`'s slot indices. Must be
+        // called once, after the parent tree's `table_mutable` has been initialized, and
+        // only when `write_index_value_count_max > 0`.
+        pub fn attach_values_backing(
+            self: *CacheMap,
+            values_backing: *const []Value,
+        ) void {
+            assert(self.write_index_enabled());
+            assert(self.values_backing == null);
+            self.values_backing = values_backing;
+        }
+
+        // Callback registered with the parent tree's `table_mutable` so the cache_map's
+        // `write_index` is automatically re-aligned after every full or incremental sort
+        // of `values_used`. The `*anyopaque` context is the `*CacheMap`.
+        pub fn sort_callback(
+            context: *anyopaque,
+            values_used: []const Value,
+            offset_after_sort: u32,
+        ) void {
+            const self: *CacheMap = @ptrCast(@alignCast(context));
+            self.rebuild_write_index_suffix(values_used, offset_after_sort);
         }
 
         pub fn deinit(self: *CacheMap, allocator: std.mem.Allocator) void {
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
             assert(self.stash.count() <= self.options.stash_value_count_max);
+            assert(self.write_index.count() <= self.options.write_index_value_count_max);
 
             self.scope_rollback_log.deinit(allocator);
             self.stash.deinit(allocator);
+            self.write_index.deinit(allocator);
             if (self.cache) |*cache| cache.deinit(allocator);
         }
 
@@ -125,16 +180,24 @@ pub fn CacheMapType(
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
             assert(self.stash.count() <= self.options.stash_value_count_max);
+            assert(self.write_index.count() <= self.options.write_index_value_count_max);
 
             if (self.cache) |*cache| cache.reset();
             self.stash.clearRetainingCapacity();
+            self.write_index.clearRetainingCapacity();
 
             self.* = .{
                 .cache = self.cache,
+                .write_index = self.write_index,
                 .stash = self.stash,
+                .values_backing = self.values_backing,
                 .scope_rollback_log = self.scope_rollback_log,
                 .options = self.options,
             };
+        }
+
+        pub inline fn write_index_enabled(self: *const CacheMap) bool {
+            return self.options.write_index_value_count_max > 0;
         }
 
         pub fn has(self: *const CacheMap, key: Key) bool {
@@ -142,20 +205,46 @@ pub fn CacheMapType(
         }
 
         pub fn get(self: *const CacheMap, key: Key) ?*Value {
-            return (if (self.cache) |*cache| cache.get(key) else null) orelse
-                self.stash.getKeyPtr(tombstone_from_key(key));
+            if (self.cache) |*cache| {
+                if (cache.get(key)) |v| {
+                    if (constants.verify) assert(key_from_value(v) == key);
+                    return v;
+                }
+            }
+            if (self.write_index_enabled()) {
+                if (self.write_index.get(key)) |slot| {
+                    const values = self.values_backing.?.*;
+                    assert(slot < values.len);
+                    const value_ptr = &values[slot];
+                    // The slot must hold a value with the looked-up key, otherwise
+                    // `write_index` is out of sync with `tree.table_mutable.values`.
+                    assert(key_from_value(value_ptr) == key);
+                    // A tombstone in the mutable table means "logically removed within
+                    // this bar". Surface it as "not present" to match the semantics that
+                    // `cache_map.remove(key)` followed by `cache_map.get(key)` returns null.
+                    if (tombstone(value_ptr)) return null;
+                    return value_ptr;
+                }
+            }
+            return self.stash.getKeyPtr(tombstone_from_key(key));
         }
 
-        pub fn upsert(self: *CacheMap, value: *const Value) void {
-            const old_value_maybe = self.fetch_upsert(value);
+        // `slot` is the index in the parent tree's `table_mutable.values` where this value
+        // also lives. Pass `slot = null` for values that are NOT mirrored in the mutable
+        // table (prefetch loads, orphaned-id sentinels, SAC eviction recovery copies). When
+        // `write_index_value_count_max == 0`, `slot` is required to be null.
+        pub fn upsert(self: *CacheMap, value: *const Value, slot: ?u32) void {
+            if (slot != null) assert(self.write_index_enabled());
 
-            // When upserting into a scope:
+            const old_value_maybe = self.fetch_upsert(value, slot);
+
             if (self.scope_is_active) {
                 if (old_value_maybe) |old_value| {
-                    // If it was updated, append the old value to the scope rollback log.
+                    // The previous version of this key (if any).
                     self.scope_rollback_log.appendAssumeCapacity(old_value);
                 } else {
-                    // If it was an insert, append a tombstone to the scope rollback log.
+                    // No previous version: it was a fresh insert. Record a tombstone so the
+                    // discard path knows to remove the key.
                     const key = key_from_value(value);
                     const key_tombstone = tombstone_from_key(key);
                     self.scope_rollback_log.appendAssumeCapacity(key_tombstone);
@@ -163,54 +252,94 @@ pub fn CacheMapType(
             }
         }
 
-        // Upserts the cache and stash and returns the old value in case of
-        // an update.
-        fn fetch_upsert(self: *CacheMap, value: *const Value) ?Value {
-            if (self.cache) |*cache| {
-                const key = key_from_value(value);
-                const result = cache.upsert(value);
-
-                if (result.evicted) |*evicted| {
-                    switch (result.updated) {
-                        .update => {
-                            assert(key_from_value(evicted) == key);
-                            if (constants.verify) assert(!self.stash.contains(value.*));
-
-                            // There was an eviction because an item was updated,
-                            // the evicted item is always its previous version.
-                            return evicted.*;
-                        },
-                        .insert => {
-                            assert(key_from_value(evicted) != key);
-
-                            // There was an eviction because a new item was inserted,
-                            // the evicted item will be added to the stash.
-                            const stash_updated = self.stash_upsert(evicted);
-
-                            // We don't expect stale values on the stash.
-                            assert(stash_updated == null);
-                        },
-                    }
-                } else {
-                    // It must be an insert without eviction,
-                    // since updates always evict the old version.
-                    assert(result.updated == .insert);
-                }
-
-                // The stash may have the old value if nothing was evicted.
-                return self.stash_remove(key);
+        // Upserts the cache, write_index and stash. Returns the old value if this upsert
+        // replaces an existing live entry.
+        fn fetch_upsert(self: *CacheMap, value: *const Value, slot: ?u32) ?Value {
+            if (self.cache != null) {
+                return self.fetch_upsert_with_cache(value, slot);
             } else {
-                // No cache.
-                // Upserting the stash directly.
-                return self.stash_upsert(value);
+                return self.fetch_upsert_no_cache(value, slot);
             }
+        }
+
+        fn fetch_upsert_with_cache(
+            self: *CacheMap,
+            value: *const Value,
+            slot: ?u32,
+        ) ?Value {
+            const key = key_from_value(value);
+            const cache = &self.cache.?;
+            const result = cache.upsert(value);
+
+            var old_value: ?Value = null;
+            if (result.evicted) |*evicted| switch (result.updated) {
+                .update => {
+                    assert(key_from_value(evicted) == key);
+                    if (constants.verify) assert(!self.stash.contains(value.*));
+                    // Previous version of THIS key.
+                    old_value = evicted.*;
+                },
+                .insert => {
+                    assert(key_from_value(evicted) != key);
+                    // Eviction-time recovery: drop the eviction if the evicted key still
+                    // has a live copy reachable through `write_index`; otherwise preserve
+                    // it in the stash.
+                    const evicted_key = key_from_value(evicted);
+                    if (self.write_index_enabled() and
+                        self.write_index.contains(evicted_key))
+                    {
+                        // Drop. Mutable table still has the latest version.
+                    } else {
+                        const stash_updated = self.stash_upsert(evicted);
+                        assert(stash_updated == null);
+                    }
+                },
+            } else {
+                // No eviction means a fresh slot; updates always evict the old value.
+                assert(result.updated == .insert);
+            }
+
+            // Record the new slot for slot=some callers so a later SAC eviction of this
+            // key falls through to the live copy in `mutable.values`.
+            if (slot) |s| self.write_index.putAssumeCapacity(key, s);
+
+            // A stale prefetch entry for `key` (if any) is now superseded by the cache.
+            const stash_old = self.stash_remove(key);
+            return old_value orelse stash_old;
+        }
+
+        fn fetch_upsert_no_cache(
+            self: *CacheMap,
+            value: *const Value,
+            slot: ?u32,
+        ) ?Value {
+            const key = key_from_value(value);
+            if (slot) |s| {
+                // Mirror in `write_index`. The previous slot for this key (if any) becomes
+                // a shadow in `mutable.values` that the next `sort_suffix` dedup folds
+                // out. Returning the previous-slot value satisfies the scope rollback
+                // contract.
+                const old_slot_kv = self.write_index.fetchPutAssumeCapacity(key, s);
+                const stash_old = self.stash_remove(key);
+                if (old_slot_kv) |kv| {
+                    const values = self.values_backing.?.*;
+                    assert(kv.value < values.len);
+                    const prev = values[kv.value];
+                    assert(key_from_value(&prev) == key);
+                    return prev;
+                }
+                return stash_old;
+            }
+            // `slot=null` and no SAC: pure stash semantics, identical to the
+            // pre-write_index code path.
+            return self.stash_upsert(value);
         }
 
         fn stash_upsert(self: *CacheMap, value: *const Value) ?Value {
             defer assert(self.stash.count() <= self.options.stash_value_count_max);
-            // Using `getOrPutAssumeCapacity` instead of `putAssumeCapacity` is
-            // critical, since we use HashMaps with no Value, `putAssumeCapacity`
-            // _will not_ clobber the existing value.
+            // Using `getOrPutAssumeCapacity` instead of `putAssumeCapacity` is critical,
+            // since we use HashMaps with void Value, `putAssumeCapacity` _will not_ clobber
+            // the existing key entry.
             const gop = self.stash.getOrPutAssumeCapacity(value.*);
             defer gop.key_ptr.* = value.*;
 
@@ -230,17 +359,31 @@ pub fn CacheMapType(
             else
                 null;
 
-            // We don't allow stale values, so we need to remove from the stash as well,
-            // since both can have different versions with the same key.
+            // Remove from write_index AND stash, since either may hold a different version
+            // of the same key.
+            const write_index_removed: ?Value = self.write_index_remove(key);
             const stash_removed: ?Value = self.stash_remove(key);
 
             if (self.scope_is_active) {
-                // TODO: Actually, does the fuzz catch this...
                 self.scope_rollback_log.appendAssumeCapacity(
                     cache_removed orelse
+                        write_index_removed orelse
                         stash_removed orelse return,
                 );
             }
+        }
+
+        fn write_index_remove(self: *CacheMap, key: Key) ?Value {
+            if (!self.write_index_enabled()) return null;
+            const kv = self.write_index.fetchRemove(key) orelse return null;
+            const values = self.values_backing.?.*;
+            assert(kv.value < values.len);
+            const value = values[kv.value];
+            // Mirror the safety net in `get`: the slot must hold a value with the key we
+            // removed, otherwise `write_index` is out of sync with `values_backing` and
+            // whatever we return would silently corrupt the scope rollback log.
+            assert(key_from_value(&value) == key);
+            return value;
         }
 
         fn stash_remove(self: *CacheMap, key: Key) ?Value {
@@ -251,8 +394,8 @@ pub fn CacheMapType(
                 null;
         }
 
-        /// Start a new scope. Within a scope, changes can be persisted
-        /// or discarded. At most one scope can be active at a time.
+        /// Start a new scope. Within a scope, changes can be persisted or discarded.
+        /// At most one scope can be active at a time.
         pub fn scope_open(self: *CacheMap) void {
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
@@ -263,48 +406,109 @@ pub fn CacheMapType(
             assert(self.scope_is_active);
             self.scope_is_active = false;
 
-            // We don't need to do anything to persist a scope.
             if (mode == .persist) {
                 self.scope_rollback_log.clearRetainingCapacity();
                 return;
             }
 
-            // The scope_rollback_log stores the operations we need to reverse the changes a scope
-            // made. They get replayed in reverse order.
+            // The scope_rollback_log stores the operations we need to reverse the changes a
+            // scope made. They get replayed in reverse order. The replays touch the SAC and
+            // stash; for write_index entries, the replay is a no-op (slot=null upserts skip
+            // write_index). After this loop, `Groove.scope_close` calls
+            // `rebuild_write_index_full` to reconstruct write_index from the post-rewind
+            // tree state.
             var i: usize = self.scope_rollback_log.items.len;
             while (i > 0) {
                 i -= 1;
 
                 const rollback_value = &self.scope_rollback_log.items[i];
                 if (tombstone(rollback_value)) {
-                    // Reverting an insert consists of a .remove call.
-                    // The value in here will be a tombstone indicating the original value didn't
-                    // exist.
+                    // Reverting an insert consists of a .remove call. The value here is a
+                    // tombstone indicating the original value did not exist.
                     const key = key_from_value(rollback_value);
 
-                    // A tombstone in the rollback log can only occur when the value doesn't exist
-                    // in _both_ the cache and stash on insert.
-                    const cache_removed =
-                        if (self.cache) |*cache| cache.remove(key) != null else false;
-
-                    // The key should be in the stash iff it wasn't in the cache.
+                    const cache_removed = if (self.cache) |*cache|
+                        cache.remove(key) != null
+                    else
+                        false;
+                    const write_index_removed = if (self.write_index_enabled())
+                        self.write_index.remove(key)
+                    else
+                        false;
                     const stash_removed = self.stash_remove(key) != null;
-                    assert(stash_removed != cache_removed);
+                    // The key was in at least one of cache / write_index / stash before
+                    // rollback. With both cache and write_index present, a slot=some insert
+                    // populates both, so present_count may be 2.
+                    assert(cache_removed or write_index_removed or stash_removed);
                 } else {
-                    // Reverting an update or delete consists of an insert of the original value.
-                    self.upsert(rollback_value);
+                    // Reverting an update or delete consists of an insert of the original
+                    // value. We don't know the slot of the original (it was lost when we
+                    // appended the value to the rollback log), so we route via slot=null.
+                    // The subsequent `rebuild_write_index_full` call from
+                    // `Groove.scope_close` will reconstitute write_index from the
+                    // post-rewind mutable values.
+                    self.upsert(rollback_value, null);
                 }
             }
 
             self.scope_rollback_log.clearRetainingCapacity();
         }
 
+        // Rebuild `write_index` over the suffix `[offset..values_used.len)`. Used by
+        // `Groove.compact` after each per-beat `tree.compact()` (which sorts and dedupes the
+        // suffix). The walk is forward and last-wins per key:
+        //   - tombstones erase any prior write_index entry for the key (preserving the
+        //     existing semantic that a removed key is reported absent by `cache_map.has`),
+        //   - non-tombstones overwrite.
+        // The stable prefix `[0..offset)` is left untouched.
+        pub fn rebuild_write_index_suffix(
+            self: *CacheMap,
+            values_used: []const Value,
+            offset: u32,
+        ) void {
+            assert(self.write_index_enabled());
+            assert(self.values_backing != null);
+            assert(offset <= values_used.len);
+
+            var i: u32 = offset;
+            while (i < values_used.len) : (i += 1) {
+                const v = &values_used[i];
+                const k = key_from_value(v);
+                if (tombstone(v)) {
+                    _ = self.write_index.remove(k);
+                } else {
+                    self.write_index.putAssumeCapacity(k, i);
+                }
+            }
+        }
+
+        // Full rebuild over `[0..values_used.len)`. Used by `Groove.scope_close(.discard)`
+        // after the tree rewinds `value_context.count`. Clears `write_index` first to drop
+        // stale entries pointing past the rewind boundary, then walks forward with the
+        // same tombstone-erases / non-tombstone-overwrites semantics as the suffix rebuild.
+        pub fn rebuild_write_index_full(self: *CacheMap, values_used: []const Value) void {
+            assert(self.write_index_enabled());
+            assert(self.values_backing != null);
+
+            self.write_index.clearRetainingCapacity();
+            for (values_used, 0..) |*v, i| {
+                const k = key_from_value(v);
+                if (tombstone(v)) {
+                    _ = self.write_index.remove(k);
+                } else {
+                    self.write_index.putAssumeCapacity(k, @intCast(i));
+                }
+            }
+        }
+
         pub fn compact(self: *CacheMap) void {
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
             assert(self.stash.count() <= self.options.stash_value_count_max);
+            assert(self.write_index.count() <= self.options.write_index_value_count_max);
 
             self.stash.clearRetainingCapacity();
+            self.write_index.clearRetainingCapacity();
         }
     };
 }
@@ -353,6 +557,9 @@ test "cache_map: unit" {
 
     const allocator = testing.allocator;
 
+    // Unit test exercises the SAC + stash path with cache != null and write_index disabled,
+    // matching the original semantics. Slot-aware coverage is exercised end-to-end via
+    // forest_fuzz / VOPR through the real Account groove.
     var cache_map = try TestCacheMap.init(allocator, .{
         .cache_value_count_max = TestCacheMap.Cache.value_count_max_multiple,
         .scope_value_count_max = 32,
@@ -361,7 +568,7 @@ test "cache_map: unit" {
     });
     defer cache_map.deinit(allocator);
 
-    cache_map.upsert(&.{ .key = 1, .value = 1, .tombstone = false });
+    cache_map.upsert(&.{ .key = 1, .value = 1, .tombstone = false }, null);
     try testing.expectEqual(
         TestTable.Value{ .key = 1, .value = 1, .tombstone = false },
         cache_map.get(1).?.*,
@@ -369,7 +576,7 @@ test "cache_map: unit" {
 
     // Test scope persisting
     cache_map.scope_open();
-    cache_map.upsert(&.{ .key = 2, .value = 2, .tombstone = false });
+    cache_map.upsert(&.{ .key = 2, .value = 2, .tombstone = false }, null);
     try testing.expectEqual(
         TestTable.Value{ .key = 2, .value = 2, .tombstone = false },
         cache_map.get(2).?.*,
@@ -382,9 +589,9 @@ test "cache_map: unit" {
 
     // Test scope discard on updates
     cache_map.scope_open();
-    cache_map.upsert(&.{ .key = 2, .value = 22, .tombstone = false });
-    cache_map.upsert(&.{ .key = 2, .value = 222, .tombstone = false });
-    cache_map.upsert(&.{ .key = 2, .value = 2222, .tombstone = false });
+    cache_map.upsert(&.{ .key = 2, .value = 22, .tombstone = false }, null);
+    cache_map.upsert(&.{ .key = 2, .value = 222, .tombstone = false }, null);
+    cache_map.upsert(&.{ .key = 2, .value = 2222, .tombstone = false }, null);
     try testing.expectEqual(
         TestTable.Value{ .key = 2, .value = 2222, .tombstone = false },
         cache_map.get(2).?.*,
@@ -397,12 +604,12 @@ test "cache_map: unit" {
 
     // Test scope discard on inserts
     cache_map.scope_open();
-    cache_map.upsert(&.{ .key = 3, .value = 3, .tombstone = false });
+    cache_map.upsert(&.{ .key = 3, .value = 3, .tombstone = false }, null);
     try testing.expectEqual(
         TestTable.Value{ .key = 3, .value = 3, .tombstone = false },
         cache_map.get(3).?.*,
     );
-    cache_map.upsert(&.{ .key = 3, .value = 33, .tombstone = false });
+    cache_map.upsert(&.{ .key = 3, .value = 33, .tombstone = false }, null);
     try testing.expectEqual(
         TestTable.Value{ .key = 3, .value = 33, .tombstone = false },
         cache_map.get(3).?.*,

--- a/src/lsm/cache_map_fuzz.zig
+++ b/src/lsm/cache_map_fuzz.zig
@@ -69,7 +69,11 @@ const Environment = struct {
                     env.model.compact();
                 },
                 .upsert => |value| {
-                    env.cache_map.upsert(&value);
+                    // The fuzz drives the slot=null path only (the SAC + stash path).
+                    // The slot=some path is exercised end-to-end via forest_fuzz / VOPR
+                    // through the real Account groove, since the cache_map fuzz has no
+                    // backing values buffer to point slot indices into.
+                    env.cache_map.upsert(&value, null);
                     try env.model.upsert(&value);
                 },
                 .remove => |key| {

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -629,16 +629,34 @@ pub fn GrooveType(
                 .scan_builder = undefined,
             };
 
+            // write_index holds the slot=some upsert population (writes) when the SAC is
+            // non-empty; the stash then only needs to hold slot=null upserts. SAC absent
+            // keeps the historical single-stash bound.
+            const write_index_max: u32 = if (options.cache_entries_max > 0)
+                constants.lsm_compaction_ops *
+                    options.tree_options_object.batch_value_count_limit
+            else
+                0;
+
+            // Stash sizing. With SAC present, writes live in write_index; the stash holds
+            // prefetch loads, plus orphan-id sentinels for grooves with `orphaned_ids`
+            // (see `insert_orphaned_id` / `state_machine.zig:3164`). With SAC absent the
+            // historical `lsm_compaction_ops * (batch + prefetch)` bound applies.
+            const orphan_max: u32 = if (groove_options.orphaned_ids)
+                options.tree_options_object.batch_value_count_limit
+            else
+                0;
+            const stash_max: u32 = constants.lsm_compaction_ops *
+                (if (options.cache_entries_max > 0)
+                    options.prefetch_entries_for_read_max + orphan_max
+                else
+                    options.tree_options_object.batch_value_count_limit +
+                        options.prefetch_entries_for_read_max);
+
             groove.objects_cache = if (ObjectsCache != void) try ObjectsCache.init(allocator, .{
                 .cache_value_count_max = options.cache_entries_max,
-                // In the worst case, each stash must be able to store
-                // batch_value_count_limit per beat (to contain either TableMutable or
-                // TableImmutable) as well as the maximum number of prefetches a bar may
-                // perform, excluding prefetches already accounted
-                // for by batch_value_count_limit.
-                .stash_value_count_max = constants.lsm_compaction_ops *
-                    (options.tree_options_object.batch_value_count_limit +
-                        options.prefetch_entries_for_read_max),
+                .write_index_value_count_max = write_index_max,
+                .stash_value_count_max = stash_max,
 
                 // Scopes are limited to a single beat, so the maximum number of entries in
                 // a single scope is batch_value_count_limit (total – not per beat).
@@ -668,6 +686,20 @@ pub fn GrooveType(
                 options.tree_options_object,
             );
             errdefer groove.objects.deinit(allocator);
+
+            // Wire write_index to the tree's mutable values. The cache_map stores a stable
+            // pointer to the slice header so `compact`/`absorb` buffer swaps are observed
+            // freshly on every lookup. The sort callback re-aligns slot indices after any
+            // sort_suffix/sort on the tree's mutable.
+            if (ObjectsCache != void and options.cache_entries_max > 0) {
+                groove.objects_cache.attach_values_backing(
+                    &groove.objects.table_mutable.values,
+                );
+                groove.objects.table_mutable.attach_sort_callback(
+                    &groove.objects_cache,
+                    @TypeOf(groove.objects_cache).sort_callback,
+                );
+            }
 
             if (has_id) try groove.ids.init(
                 allocator,
@@ -891,11 +923,14 @@ pub fn GrooveType(
                         assert(groove_options.orphaned_ids);
 
                         // Zeroed timestamp indicates the object is not present,
-                        // and this id cannot be used anymore.
+                        // and this id cannot be used anymore. The sentinel does not live
+                        // in the tree's mutable table, so it routes through the stash via
+                        // slot=null.
                         groove.objects_cache.upsert(
                             &std.mem.zeroInit(Object, .{
                                 .id = id_tree_value.id,
                             }),
+                            null,
                         );
                     } else {
                         if (groove.prefetch_keys.get(.{
@@ -956,9 +991,11 @@ pub fn GrooveType(
                 .positive => |object| {
                     assert(!ObjectTreeHelper.tombstone(object));
                     switch (lookup_by) {
-                        .primary_key => groove.objects_cache.upsert(object),
+                        // Loaded from the LSM tree levels (not from `tree.table_mutable`),
+                        // so it routes through the stash via slot=null.
+                        .primary_key => groove.objects_cache.upsert(object, null),
                         .timestamp => if (has_id) {
-                            groove.objects_cache.upsert(object);
+                            groove.objects_cache.upsert(object, null);
                             groove.timestamps.set(object.timestamp, .{ .found = object.id });
                         } else unreachable,
                     }
@@ -1175,11 +1212,14 @@ pub fn GrooveType(
                         comptime assert(has_id);
 
                         // Zeroed timestamp indicates the object is not present,
-                        // and this id cannot be used anymore.
+                        // and this id cannot be used anymore. The sentinel does not live
+                        // in the tree's mutable table, so it routes through the stash via
+                        // slot=null.
                         worker.context.groove.objects_cache.upsert(
                             &std.mem.zeroInit(Object, .{
                                 .id = id_tree_value.id,
                             }),
+                            null,
                         );
                     } else if (!id_tree_value.tombstone()) {
                         worker.lookup_by_timestamp(id_tree_value.timestamp);
@@ -1243,9 +1283,11 @@ pub fn GrooveType(
                     }
 
                     switch (entry.lookup_by) {
-                        .primary_key => worker.context.groove.objects_cache.upsert(object),
+                        // Loaded from disk (or tree levels), not from `tree.table_mutable`,
+                        // so it routes through the stash via slot=null.
+                        .primary_key => worker.context.groove.objects_cache.upsert(object, null),
                         .timestamp => if (has_id) {
-                            worker.context.groove.objects_cache.upsert(object);
+                            worker.context.groove.objects_cache.upsert(object, null);
                             worker.context.groove.timestamps.set(
                                 object.timestamp,
                                 .{ .found = object.id },
@@ -1273,7 +1315,15 @@ pub fn GrooveType(
 
             if (ObjectsCache != void) {
                 assert(!groove.objects_cache.has(@field(object, primary_field)));
-                groove.objects_cache.upsert(object);
+                // Capture the slot the next `tree.put` will write to and thread it into
+                // `objects_cache`. This is a no-op (slot=null) when the cache_map's
+                // write_index is disabled. The peek and the put must remain a single,
+                // uninterrupted pair so the slot stays meaningful.
+                const slot: ?u32 = if (groove.objects_cache.write_index_enabled())
+                    groove.objects.peek_next_slot()
+                else
+                    null;
+                groove.objects_cache.upsert(object, slot);
             }
 
             if (has_id) {
@@ -1357,7 +1407,15 @@ pub fn GrooveType(
             // unless old comes from the stash) and no secondary indexes will be updated!
 
             if (ObjectsCache != void) {
-                groove.objects_cache.upsert(new);
+                // Capture the slot for the upcoming `tree.put(new)` and thread it through.
+                // The previous slot for this key (if any) becomes a shadow in mutable.values
+                // that the next sort_suffix's dedup will fold out. No-op (slot=null) when
+                // the cache_map's write_index is disabled for this groove.
+                const slot: ?u32 = if (groove.objects_cache.write_index_enabled())
+                    groove.objects.peek_next_slot()
+                else
+                    null;
+                groove.objects_cache.upsert(new, slot);
             }
             groove.objects.put(new);
         }
@@ -1404,7 +1462,13 @@ pub fn GrooveType(
             assert(groove.ids.active_scope == null);
             assert(!groove.objects_cache.has(id));
 
-            groove.objects_cache.upsert(&std.mem.zeroInit(Object, .{ .id = id }));
+            // The sentinel does not live in the tree's mutable table (we only put into
+            // `groove.ids`, not `groove.objects`), so it routes through the stash via
+            // slot=null.
+            groove.objects_cache.upsert(
+                &std.mem.zeroInit(Object, .{ .id = id }),
+                null,
+            );
             groove.ids.put(&.{ .id = id, .timestamp = 0 });
             groove.ids.key_range_update(id);
         }
@@ -1435,6 +1499,10 @@ pub fn GrooveType(
         }
 
         pub fn scope_close(groove: *Groove, mode: ScopeCloseMode) void {
+            // Order matters: cache_map.scope_close runs FIRST so its rollback log replay
+            // observes the pre-rewind tree state. Then tree.scope_close rewinds the
+            // mutable count. Finally, on .discard with write_index enabled, walk the
+            // post-rewind values to re-establish write_index slot pointers.
             if (ObjectsCache != void) groove.objects_cache.scope_close(mode);
 
             if (has_id) {
@@ -1445,18 +1513,31 @@ pub fn GrooveType(
             inline for (std.meta.fields(IndexTrees)) |field| {
                 @field(groove.indexes, field.name).scope_close(mode);
             }
+
+            if (ObjectsCache != void and mode == .discard and
+                groove.objects_cache.write_index_enabled())
+            {
+                groove.objects_cache.rebuild_write_index_full(
+                    groove.objects.table_mutable.values_used(),
+                );
+            }
         }
 
         pub fn compact(groove: *Groove, op: u64) void {
             if (has_id) groove.ids.compact();
+
+            // When the cache_map's write_index is enabled, the rebuild happens
+            // automatically inside `tree.compact()` -> `table_mutable.sort_suffix()` via
+            // the sort callback the groove wired during init. No explicit rebuild call is
+            // needed here.
             groove.objects.compact();
 
             inline for (std.meta.fields(IndexTrees)) |field| {
                 @field(groove.indexes, field.name).compact();
             }
 
-            // Compact the objects_cache on the last beat of the bar, just like the trees do to
-            // their mutable tables.
+            // Compact the objects_cache on the last beat of the bar, just like the trees do
+            // to their mutable tables.
             if (ObjectsCache != void) {
                 const compaction_beat = op % constants.lsm_compaction_ops;
                 if (compaction_beat == constants.lsm_compaction_ops - 1) {

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -777,8 +777,9 @@ const Environment = struct {
             indexes_in_queries,
         ) orelse return false;
         // Simulate what prefetch does in the real state machine: ensure the old object is in
-        // the objects cache before calling update, which asserts its presence.
-        env.forest.grooves.things.objects_cache.upsert(old);
+        // the objects cache before calling update, which asserts its presence. Prefetch
+        // loads come from outside the mutable table, so slot=null routes through the stash.
+        env.forest.grooves.things.objects_cache.upsert(old, null);
         env.forest.grooves.things.update(.{ .old = old, .new = &new });
         env.model.items[model_index] = new;
 
@@ -796,8 +797,9 @@ const Environment = struct {
         const thing = &env.model.items[model_index];
 
         // Simulate what prefetch does in the real state machine: ensure the object is in
-        // the objects cache before calling remove, which asserts its presence.
-        env.forest.grooves.things.objects_cache.upsert(thing);
+        // the objects cache before calling remove, which asserts its presence. Prefetch
+        // loads come from outside the mutable table, so slot=null routes through the stash.
+        env.forest.grooves.things.objects_cache.upsert(thing, null);
         env.forest.grooves.things.remove(thing.id);
 
         env.model_live.setValue(model_index, false);

--- a/src/lsm/table_memory.zig
+++ b/src/lsm/table_memory.zig
@@ -42,10 +42,23 @@ pub fn TableMemoryType(comptime Table: type) type {
     return struct {
         const TableMemory = @This();
 
+        // Optional callback fired after `mutable_sort_suffix_from_offset` reorders
+        // `values_used[offset..]`. Used by the parent groove to keep an external
+        // `(key -> slot)` index aligned to the post-sort layout. `offset` is 0 for a full
+        // sort and the prior `last_sorted_run_max` for an incremental one.
+        pub const SortCallback = ?*const fn (
+            context: *anyopaque,
+            values_used: []const Value,
+            offset_after_sort: u32,
+        ) void;
+
         values: []Value,
         value_context: ValueContext,
         mutability: Mutability,
         name: []const u8,
+
+        sort_callback: SortCallback = null,
+        sort_callback_context: ?*anyopaque = null,
 
         // Maintains per-table mutable state that must be snapshotted for “scopes”.
         // When a scope is opened (e.g., in `tree.zig`), we copy `ValueContext` so we can
@@ -347,6 +360,9 @@ pub fn TableMemoryType(comptime Table: type) type {
 
             table.value_context.run_tracker.reset();
 
+            // Preserve `sort_callback` and `sort_callback_context` across resets. They are
+            // installed once per groove init by the parent cache_map and must outlive every
+            // bar boundary; this `table.* = .{...}` would otherwise zero them.
             table.* = .{
                 .values = table.values,
                 .value_context = .{
@@ -354,6 +370,8 @@ pub fn TableMemoryType(comptime Table: type) type {
                 },
                 .mutability = mutability,
                 .name = table.name,
+                .sort_callback = table.sort_callback,
+                .sort_callback_context = table.sort_callback_context,
             };
         }
 
@@ -363,6 +381,33 @@ pub fn TableMemoryType(comptime Table: type) type {
 
         pub fn values_used(table: *const TableMemory) []Value {
             return table.values[0..table.count()];
+        }
+
+        // The exclusive upper bound of the most recently sorted run, or 0 if no run exists.
+        // Used by `Groove.compact` to walk only the newly-sorted suffix after `sort_suffix`,
+        // when an external `(key -> slot)` index needs to be re-aligned to `values_used()`.
+        pub fn last_sorted_run_max(table: *const TableMemory) u32 {
+            if (table.value_context.run_tracker.last()) |run| {
+                return run.max;
+            }
+            return 0;
+        }
+
+        // Register a sort callback. Must be called once, before any sort/sort_suffix call.
+        // See `SortCallback` above for the contract.
+        pub fn attach_sort_callback(
+            table: *TableMemory,
+            context: *anyopaque,
+            callback: *const fn (
+                context: *anyopaque,
+                values_used: []const Value,
+                offset_after_sort: u32,
+            ) void,
+        ) void {
+            assert(table.sort_callback == null);
+            assert(table.sort_callback_context == null);
+            table.sort_callback = callback;
+            table.sort_callback_context = context;
         }
 
         // Appends a `value`. If it is strictly greater than the previous key,
@@ -586,6 +631,18 @@ pub fn TableMemoryType(comptime Table: type) type {
                 offset,
             );
             table.value_context.count = target_count;
+
+            // Notify the parent groove (via the registered callback) that the suffix
+            // `[offset..target_count)` has been freshly sorted, so any external
+            // `(key -> slot)` index that mirrors `values_used` can be re-aligned.
+            if (table.sort_callback) |callback| {
+                callback(
+                    table.sort_callback_context.?,
+                    table.values_used(),
+                    offset,
+                );
+            }
+
             return .{ .min = offset, .max = target_count, .origin = .mutable };
         }
 

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -204,6 +204,25 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             tree.table_mutable.put(&Table.tombstone_from_key(Table.key_from_value(value)));
         }
 
+        // The slot in `table_mutable.values` that the next `put` will write to. Captured by
+        // `Groove.insert`/`Groove.update` immediately before `put`, and threaded into the
+        // `objects_cache`'s `write_index` so the cache can store a slot index instead of a
+        // duplicated value. Calling `peek_next_slot` then `put` must be a single, uninterrupted
+        // pair to keep the slot meaningful.
+        pub fn peek_next_slot(tree: *const Tree) u32 {
+            assert(tree.table_mutable.mutability == .mutable);
+            return tree.table_mutable.count();
+        }
+
+        // The exclusive upper bound of the most recently sorted run in `table_mutable`.
+        // Captured by `Groove.compact` before calling `tree.compact()` so it knows where the
+        // newly-sorted suffix begins, when re-aligning the cache_map's `write_index` to the
+        // post-sort layout of `values_used`.
+        pub fn last_sorted_run_max(tree: *const Tree) u32 {
+            assert(tree.table_mutable.mutability == .mutable);
+            return tree.table_mutable.last_sorted_run_max();
+        }
+
         pub fn key_range_update(tree: *Tree, key: Key) void {
             if (tree.key_range) |*key_range| {
                 if (key < key_range.key_min) key_range.key_min = key;


### PR DESCRIPTION
`Groove.objects_cache` currently duplicates every written Account between `tree.table_mutable.values` and the `stash`. For grooves with a non-empty SAC, this PR replaces that duplication with a `write_index: HashMap(PrimaryKey, u32)` whose values are slot indices into `table_mutable.values`, and shrinks the stash to only hold slot=null upserts (prefetch loads, and orphan-id sentinels on grooves with `orphaned_ids`).

Opt-in per groove via a new `write_index_value_count_max` on `CacheMapType.Options`. `Transfer` and `TransferPending` pass 0 and behave identically to today; only `Account` enables it.

A `sort_callback` on `TableMemory` re-aligns `write_index` after every `sort_suffix`/`sort`, so `tree.compact`, `prefetch_enqueue_by_timestamp`, `ScanTree.init`, and `ScanLookup.lookup_start` all stay consistent without per-call-site hooks. `groove.scope_close(.discard)` calls `rebuild_write_index_full` after the tree rewinds, so scopes work too. Bar-boundary clear happens in `cache_map.compact()` which runs before `forest.swap_mutable_and_immutable`, so there is no window where a stale slot index could observe a swapped buffer.

10M-transfer benchmark, default config, 1 replica, 1 client, ARM64 Linux:

```
                                 main       patched    delta
CountingAllocator.live_size()  3021 MiB   2848 MiB    -173
getMaxRss() peak               3028 MiB   2855 MiB    -173
```

Throughput stays inside the baseline variance band (562-637K tx/s baseline vs 566-596K patched over 3 runs each). Combined with #3631 on the same replica this is -209 MiB vs `main`.

Tested with `zig build test`, `zig build fuzz:build`, `zig build vopr:build`, `zig build fuzz -- lsm_cache_map`, `zig build fuzz -- lsm_forest`, `zig build fuzz -- lsm_scan`, and 20 random VOPR seeds.