### PR TITLE
stdx: add cpu_affinity

### DIFF
--- a/src/stdx/cpu_affinity.zig
+++ b/src/stdx/cpu_affinity.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+
+pub const Error = error{
+    UnsupportedPlatform,
+    InvalidCpu,
+} || std.posix.UnexpectedError;
+
+/// Pins the calling thread to the CPU with the given zero-based index.
+///
+/// Returns `error.UnsupportedPlatform` on non-Linux systems.
+/// Returns `error.InvalidCpu` if `cpu_index` exceeds the platform's cpu_set_t capacity.
+pub fn pin_current_thread(cpu_index: u16) Error!void {
+    if (comptime builtin.os.tag != .linux) return error.UnsupportedPlatform;
+
+    comptime assert(builtin.os.tag == .linux);
+
+    return pin_current_thread_linux(cpu_index);
+}
+
+fn pin_current_thread_linux(cpu_index: u16) Error!void {
+    comptime assert(builtin.os.tag == .linux);
+
+    const linux = std.os.linux;
+    var cpu_set = std.mem.zeroes(linux.cpu_set_t);
+
+    const bits_per_word = @bitSizeOf(usize);
+    const word_index: usize = @intCast(cpu_index / bits_per_word);
+    if (word_index >= cpu_set.len) return error.InvalidCpu;
+
+    const bit_index: usize = @intCast(cpu_index % bits_per_word);
+    const bit_shift: u6 = @intCast(bit_index);
+    cpu_set[word_index] = (@as(usize, 1) << bit_shift);
+
+    try linux.sched_setaffinity(0, &cpu_set);
+}

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -20,6 +20,7 @@ pub const ZipfianShuffled = @import("zipfian.zig").ZipfianShuffled;
 pub const huge_page_allocator = @import("huge_page_allocator.zig").huge_page_allocator;
 
 pub const aegis = @import("vendored/aegis.zig");
+pub const cpu_affinity = @import("cpu_affinity.zig");
 pub const dbg = @import("debug.zig").dbg;
 pub const Flags = @import("flags.zig");
 pub const memory_lock_allocated = @import("mlock.zig").memory_lock_allocated;
@@ -1157,6 +1158,7 @@ pub fn term_from_status(status: u32) std.process.Child.Term {
 comptime {
     _ = @import("bit_set.zig");
     _ = @import("bounded_array.zig");
+    _ = @import("cpu_affinity.zig");
     _ = @import("flags.zig");
     _ = @import("huge_page_allocator.zig");
     _ = @import("iops.zig");

--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -88,6 +88,9 @@ pub fn command_benchmark(
         addresses.const_slice()
     else
         &.{tigerbeetle_process.?.address};
+
+    if (args.benchmark_cpu) |cpu_index| command_benchmark_pin_cpu(cpu_index);
+
     try benchmark_load.main(allocator, io, time, addresses, args);
 
     if (tigerbeetle_process) |*p| {
@@ -167,6 +170,13 @@ fn start(allocator: std.mem.Allocator, options: struct {
     try start_args.append(arena.allocator(), options.tigerbeetle);
     try start_args.append(arena.allocator(), "start");
     try start_args.append(arena.allocator(), "--addresses=0");
+    if (options.args.replica_cpu) |cpu_index| {
+        try start_args.append(arena.allocator(), try std.fmt.allocPrint(
+            arena.allocator(),
+            "--cpu={d}",
+            .{cpu_index},
+        ));
+    }
 
     // Forward the cache options to the tigerbeetle process:
     const forward_args = &.{
@@ -224,4 +234,19 @@ fn start(allocator: std.mem.Allocator, options: struct {
     const address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, port);
 
     return .{ .child = child, .address = address };
+}
+
+fn command_benchmark_pin_cpu(cpu_index: u16) void {
+    vsr.stdx.cpu_affinity.pin_current_thread(cpu_index) catch |err| switch (err) {
+        error.UnsupportedPlatform => log.warn(
+            "benchmark: cpu pinning is not supported on this platform",
+            .{},
+        ),
+        error.InvalidCpu => vsr.fatal(
+            .cli,
+            "benchmark: cpu {d} is out of range",
+            .{cpu_index},
+        ),
+        else => vsr.fatal(.cli, "benchmark: failed to set cpu affinity ({})", .{err}),
+    };
 }

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -45,6 +45,7 @@ const CLIArgs = union(enum) {
         replica_count: u8,
         development: bool = false,
         log_debug: bool = false,
+        cpu: ?u16 = null,
 
         @"--": void,
         path: []const u8,
@@ -57,6 +58,7 @@ const CLIArgs = union(enum) {
         replica_count: u8,
         development: bool = false,
         log_debug: bool = false,
+        cpu: ?u16 = null,
 
         @"--": void,
         path: []const u8,
@@ -67,6 +69,7 @@ const CLIArgs = union(enum) {
         addresses: []const u8,
         cache_grid: ?ByteSize = null,
         development: bool = false,
+        cpu: ?u16 = null,
 
         // Everything from here until positional arguments is considered experimental, and requires
         // `--experimental` to be set. Experimental flags disable automatic upgrades with
@@ -131,6 +134,8 @@ const CLIArgs = union(enum) {
         cache_transfers: ?[]const u8 = null,
         cache_transfers_pending: ?[]const u8 = null,
         cache_grid: ?[]const u8 = null,
+        benchmark_cpu: ?u16 = null,
+        replica_cpu: ?u16 = null,
         account_count: u64 = 10_000,
         account_count_hot: u32 = 0,
         log_debug: bool = false,
@@ -407,6 +412,17 @@ const CLIArgs = union(enum) {
         \\        (Total RAM) - 3GiB (TigerBeetle) - 1GiB (System), eg 12GiB for a 16GiB machine.
         \\        Defaults to {[default_cache_grid_gb]d}GiB.
         \\
+        \\  --cpu=<index>
+        \\        Pin the format, recover, or start command process to the zero-based CPU index.
+        \\        Supported on Linux.
+        \\
+        \\  --benchmark-cpu=<index>
+        \\        Pin the benchmark load process to the zero-based CPU index. Supported on Linux.
+        \\
+        \\  --replica-cpu=<index>
+        \\        Pin the local replica process started by benchmark to the zero-based CPU index.
+        \\        Supported on Linux.
+        \\
         \\  --verbose
         \\        Print compile-time configuration along with the build version.
         \\
@@ -510,6 +526,7 @@ pub const Command = union(enum) {
         development: bool,
         path: []const u8,
         log_debug: bool,
+        cpu: ?u16,
     };
 
     pub const Recover = struct {
@@ -520,6 +537,7 @@ pub const Command = union(enum) {
         development: bool,
         path: []const u8,
         log_debug: bool,
+        cpu: ?u16,
     };
 
     pub const Start = struct {
@@ -550,6 +568,7 @@ pub const Command = union(enum) {
         log_debug: bool,
         log_trace: bool,
         statsd: ?std.net.Address,
+        cpu: ?u16,
     };
 
     pub const Version = struct {
@@ -615,6 +634,8 @@ pub const Command = union(enum) {
         file: ?[]const u8,
         addresses: ?Addresses,
         seed: ?[]const u8,
+        benchmark_cpu: ?u16,
+        replica_cpu: ?u16,
     };
 
     pub const Inspect = union(enum) {
@@ -778,6 +799,7 @@ fn parse_args_format(format: CLIArgs.Format) Command.Format {
         .development = format.development,
         .path = format.path,
         .log_debug = format.log_debug,
+        .cpu = format.cpu,
     };
 }
 
@@ -814,6 +836,7 @@ fn parse_args_recover(recover: CLIArgs.Recover) Command.Recover {
         .development = recover.development,
         .path = recover.path,
         .log_debug = recover.log_debug,
+        .cpu = recover.cpu,
     };
 }
 
@@ -823,6 +846,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
     const stable_args = .{
         "addresses",   "cache_grid",
         "development", "experimental",
+        "cpu",
     };
     inline for (std.meta.fields(@TypeOf(start))) |field| {
         @setEvalBranchQuota(4_000);
@@ -1090,6 +1114,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
             parse_address_and_port(statsd_address, "--statsd", 8125)
         else
             null,
+        .cpu = start.cpu,
     };
 }
 
@@ -1129,6 +1154,11 @@ fn parse_args_benchmark(benchmark: CLIArgs.Benchmark) Command.Benchmark {
 
     if (benchmark.addresses != null and benchmark.file != null) {
         vsr.fatal(.cli, "--file: --addresses and --file are mutually exclusive", .{});
+    }
+    // --replica-cpu is forwarded to the local replica process started by benchmark.
+    // With --addresses, benchmark connects to an existing cluster instead.
+    if (benchmark.addresses != null and benchmark.replica_cpu != null) {
+        vsr.fatal(.cli, "--replica-cpu: incompatible with --addresses", .{});
     }
 
     if (benchmark.account_batch_count == 0) {
@@ -1184,6 +1214,8 @@ fn parse_args_benchmark(benchmark: CLIArgs.Benchmark) Command.Benchmark {
         .file = benchmark.file,
         .addresses = addresses,
         .seed = benchmark.seed,
+        .benchmark_cpu = benchmark.benchmark_cpu,
+        .replica_cpu = benchmark.replica_cpu,
     };
 }
 

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -132,6 +132,8 @@ pub fn main() !void {
     switch (command) {
         .version => unreachable, // Handled earlier.
         inline .format, .start, .recover => |*args, command_storage| {
+            if (args.cpu) |cpu_index| main_pin_cpu(cpu_index, @tagName(command_storage));
+
             const direct_io: vsr.io.DirectIO =
                 if (!constants.direct_io)
                     .direct_io_disabled
@@ -621,6 +623,24 @@ fn command_amqp(gpa: mem.Allocator, time: Time, args: *const cli.Command.AMQP) !
     while (true) {
         runner.tick();
     }
+}
+
+fn main_pin_cpu(cpu_index: u16, command_name: []const u8) void {
+    stdx.cpu_affinity.pin_current_thread(cpu_index) catch |err| switch (err) {
+        error.UnsupportedPlatform => log.warn(
+            "{s}: cpu pinning is not supported on this platform",
+            .{command_name},
+        ),
+        error.InvalidCpu => vsr.fatal(
+            .cli,
+            "{s}: cpu {d} is out of range",
+            .{ command_name, cpu_index },
+        ),
+        else => vsr.fatal(.cli, "{s}: failed to set cpu affinity ({})", .{
+            command_name,
+            err,
+        }),
+    };
 }
 
 fn print_value(


### PR DESCRIPTION
Adds `stdx.cpu_affinity.pin_current_thread` and exposes CPU pinning via CLI flags:

- `--cpu` for `format`, `start`, and `recover`
- `--benchmark-cpu` to pin the benchmark load driver
- `--replica-cpu` to pin the replica subprocess spawned by benchmark

Pinning keeps threads on a fixed CPU, improving cache locality and reducing jitter.
`taskset` is not a good fit: it pins all threads of a process uniformly and cannot selectively pin only the main loop thread.

For deployment, kernel options like `isolcpus`/`nohz_full` can further reduce jitter and improve tail latency. It can also help to pin NVMe/NIC interrupt queues to separate cores so interrupt handling does not interfere with TigerBeetle’s main loop, and this must be configured at the OS level. In separate storage and network benchmarks, I saw visible improvements after pinning the IRQs.