### PR TITLE
metrics: track value_count_visible as a metric, per tree

### DIFF
--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -444,6 +444,8 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
         pub fn assert_level_table_counts(manifest: *const Manifest) void {
             var table_count_visible: u32 = 0;
             var table_count_visible_max: u32 = 0;
+            var value_count_visible: u64 = 0;
+
             for (&manifest.levels, 0..) |*manifest_level, index| {
                 const level: u8 = @intCast(index);
                 const level_table_count_visible_max =
@@ -452,6 +454,21 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
 
                 table_count_visible += manifest_level.table_count_visible;
                 table_count_visible_max += level_table_count_visible_max;
+                value_count_visible += manifest_level.value_count_visible;
+            }
+
+            if (constants.verify) {
+                var value_count_visible_verify: u64 = 0;
+                for (&manifest.levels) |*manifest_level| {
+                    var it = manifest_level.iterator(
+                        .visible,
+                        &.{snapshot_latest},
+                        .ascending,
+                        null,
+                    );
+                    while (it.next()) |table| value_count_visible_verify += table.value_count;
+                }
+                assert(value_count_visible_verify == value_count_visible);
             }
 
             manifest.tracer.gauge(
@@ -461,6 +478,10 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             manifest.tracer.gauge(
                 .{ .table_count_visible_max = .{ .tree = @enumFromInt(manifest.config.id) } },
                 table_count_visible_max,
+            );
+            manifest.tracer.gauge(
+                .{ .value_count_visible = .{ .tree = @enumFromInt(manifest.config.id) } },
+                value_count_visible,
             );
         }
 

--- a/src/lsm/manifest_level.zig
+++ b/src/lsm/manifest_level.zig
@@ -166,6 +166,9 @@ pub fn ManifestLevelType(
         // added/updated/removed, and also knows the superblock's persisted snapshots.
         table_count_visible: u32 = 0,
 
+        /// The number of values, within all tables visible to snapshot_latest.
+        value_count_visible: u64 = 0,
+
         /// A monotonically increasing generation number that is used detect invalid internal
         /// TableInfo references.
         generation: u32 = 0,
@@ -218,7 +221,10 @@ pub fn ManifestLevelType(
             const absolute_index_tables = level.tables.insert_element(node_pool, table.*);
             assert(absolute_index_tables < level.tables.len());
 
-            if (table.visible(lsm.snapshot_latest)) level.table_count_visible += 1;
+            if (table.visible(lsm.snapshot_latest)) {
+                level.table_count_visible += 1;
+                level.value_count_visible += table.value_count;
+            }
             level.generation +%= 1;
 
             level.key_range_latest.include(KeyRange{
@@ -265,6 +271,7 @@ pub fn ManifestLevelType(
 
             table.snapshot_max = snapshot;
             level.table_count_visible -= 1;
+            level.value_count_visible -= table.value_count;
             level.key_range_latest.exclude(KeyRange{
                 .key_min = table.key_min,
                 .key_max = table.key_max,
@@ -305,6 +312,7 @@ pub fn ManifestLevelType(
 
             if (table.visible(lsm.snapshot_latest)) {
                 level.table_count_visible -= 1;
+                level.value_count_visible -= table.value_count;
 
                 level.key_range_latest.exclude(.{
                     .key_min = table.key_min,

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -513,6 +513,7 @@ pub const EventMetric = union(enum) {
 
     table_count_visible: struct { tree: TreeEnum },
     table_count_visible_max: struct { tree: TreeEnum },
+    value_count_visible: struct { tree: TreeEnum },
     replica_status,
     replica_view,
     replica_log_view,
@@ -548,6 +549,7 @@ pub const EventMetric = union(enum) {
     pub const slot_limits = std.enums.EnumArray(Tag, u32).init(.{
         .table_count_visible = enum_count(TreeEnum),
         .table_count_visible_max = enum_count(TreeEnum),
+        .value_count_visible = enum_count(TreeEnum),
         .replica_status = 1,
         .replica_view = 1,
         .replica_log_view = 1,
@@ -603,6 +605,7 @@ pub const EventMetric = union(enum) {
         switch (event.*) {
             inline .table_count_visible,
             .table_count_visible_max,
+            .value_count_visible,
             .compaction_values_physical,
             .compaction_values_logical,
             => |data| {
@@ -695,6 +698,9 @@ test "EventMetric slot doesn't have collisions" {
                 .tree = g.enum_value(TreeEnum),
             } },
             .table_count_visible_max => .{ .table_count_visible_max = .{
+                .tree = g.enum_value(TreeEnum),
+            } },
+            .value_count_visible => .{ .value_count_visible = .{
                 .tree = g.enum_value(TreeEnum),
             } },
             .compaction_values_physical => .{ .compaction_values_physical = .{


### PR DESCRIPTION
This allows seeing how many objects are stored inside TigerBeetle, as well as seeing what the usable of secondary indexes looks like.

This only updates at the end of a bar, and only shows values that have been written to the LSM.