### PR TITLE
replica: Avoid recomputing the checksum.

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7360,6 +7360,7 @@ pub fn ReplicaType(
                 .request = request_header.request,
                 .operation = request_header.operation,
             };
+            // Recompute the body checksum: `.register` and `.reconfigure` mutate the body in place.
             message.header.set_checksum_body(message.body_used());
             message.header.set_checksum();
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7336,6 +7336,7 @@ pub fn ReplicaType(
 
             const latest_entry = self.journal.header_with_op(self.op).?;
             message.header.* = Header.Prepare{
+                .checksum_body = request_header.checksum_body,
                 .cluster = self.cluster,
                 .size = request_header.size,
                 .view = self.view,
@@ -7360,8 +7361,13 @@ pub fn ReplicaType(
                 .request = request_header.request,
                 .operation = request_header.operation,
             };
-            // Recompute the body checksum: `.register` and `.reconfigure` mutate the body in place.
-            message.header.set_checksum_body(message.body_used());
+
+            switch (message.header.operation) {
+                .register, .reconfigure => message.header.set_checksum_body(message.body_used()),
+                else => if (constants.verify) {
+                    assert(message.header.valid_checksum_body(message.body_used()));
+                },
+            }
             message.header.set_checksum();
 
             const size_ceil = vsr.sector_ceil(message.header.size);


### PR DESCRIPTION
While recording yesterday's IronBeetle episode, Alex and I noticed that `primary_pipeline_prepare` recomputes the body checksum, which was surprising since we assumed it only restamped the header. Digging in, we found that operations like `reconfigure` modify the body in place, so the recomputation is necessary. Added a comment to document this.