### PR TITLE
Swap checksum_body and body copy.

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1710,6 +1710,10 @@ pub fn ReplicaType(
                 message.header,
             });
 
+            if (constants.verify) {
+                assert(message.header.valid_checksum_body(message.body_used()));
+            }
+
             if (message.header.invalid()) |reason| {
                 log.warn("{}: on_message: invalid (command={}, {s})", .{
                     self.log_prefix(),

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -11425,10 +11425,11 @@ pub fn ReplicaType(
                 .previous_request_latency = 0,
             };
 
+            stdx.copy_disjoint(.exact, u8, request.body_used(), body);
             request.header.set_checksum_body(request.body_used());
             request.header.set_checksum();
 
-            stdx.copy_disjoint(.exact, u8, request.body_used(), body);
+            // Enable zero-copy Request->Prepare->WAL path by padding to disk sector.
             @memset(request.buffer[request.header.size..vsr.sector_ceil(request.header.size)], 0);
 
             self.send_message_to_replica(self.replica, request);


### PR DESCRIPTION
I _think_ this is a latent bug: the checksum and the copy into the body should be swapped. It's not ciritcal, since we rewrite the checksum into the body again later, but constructing a checksum that isn't valid seems not great.


