### PR TITLE
tests: swap expected/actual when used wrong

### DIFF
--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -351,8 +351,8 @@ test "ewah Word=u8" {
         });
     }
 
-    try std.testing.expectEqual(codec.encode_size_max(0), 0);
-    try std.testing.expectEqual(codec.encode_all(&.{}, &.{}), 0);
+    try std.testing.expectEqual(0, codec.encode_size_max(0));
+    try std.testing.expectEqual(0, codec.encode_all(&.{}, &.{}));
 }
 
 test "ewah Word=u16" {

--- a/src/list.zig
+++ b/src/list.zig
@@ -152,10 +152,10 @@ test "DoublyLinkedList LIFO" {
     list.push(&nodes[1]);
     list.push(&nodes[2]);
 
-    try std.testing.expectEqual(list.pop().?, &nodes[2]);
-    try std.testing.expectEqual(list.pop().?, &nodes[1]);
-    try std.testing.expectEqual(list.pop().?, &nodes[0]);
-    try std.testing.expectEqual(list.pop(), null);
+    try std.testing.expectEqual(&nodes[2], list.pop().?);
+    try std.testing.expectEqual(&nodes[1], list.pop().?);
+    try std.testing.expectEqual(&nodes[0], list.pop().?);
+    try std.testing.expectEqual(null, list.pop());
 }
 
 test "DoublyLinkedList fuzz" {

--- a/src/multiversion.zig
+++ b/src/multiversion.zig
@@ -291,7 +291,7 @@ test "ReleaseTriple.parse" {
         .{ .string = "65536.0.0", .result = error.InvalidRelease },
     };
     for (tests) |t| {
-        try std.testing.expectEqualDeep(ReleaseTriple.parse(t.string), t.result);
+        try std.testing.expectEqualDeep(t.result, ReleaseTriple.parse(t.string));
     }
 }
 

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -1066,7 +1066,7 @@ fn check_version(
                             TestGetChangeEventsResult,
                             reply.items,
                         );
-                        try testing.expectEqual(results_actual.len, results_expected.len);
+                        try testing.expectEqual(results_expected.len, results_actual.len);
                         for (results_actual, results_expected) |*actual, *expected| {
                             try testing.expect(expected.match(&accounts, &transfers, actual));
                         }

--- a/src/storage_fuzz.zig
+++ b/src/storage_fuzz.zig
@@ -167,8 +167,8 @@ pub fn main(gpa: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
 
             try std.testing.expectEqualSlices(
                 u8,
-                storage_data_written[start..end],
                 storage_data_stored[start..end],
+                storage_data_written[start..end],
             );
             try std.testing.expectEqualSlices(
                 u8,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1201,17 +1201,17 @@ test "quorums" {
     for (expect_replication[0..], 0..) |_, i| {
         const replicas = @as(u8, @intCast(i)) + 1;
         const actual = quorums(replicas);
-        try std.testing.expectEqual(actual.replication, expect_replication[i]);
-        try std.testing.expectEqual(actual.view_change, expect_view_change[i]);
-        try std.testing.expectEqual(actual.nack_prepare, expect_nack_prepare[i]);
-        try std.testing.expectEqual(actual.majority, expect_majority[i]);
-        try std.testing.expectEqual(actual.upgrade, expect_upgrade[i]);
+        try std.testing.expectEqual(expect_replication[i], actual.replication);
+        try std.testing.expectEqual(expect_view_change[i], actual.view_change);
+        try std.testing.expectEqual(expect_nack_prepare[i], actual.nack_prepare);
+        try std.testing.expectEqual(expect_majority[i], actual.majority);
+        try std.testing.expectEqual(expect_upgrade[i], actual.upgrade);
 
         // The nack quorum only differs from the view-change quorum when R=2.
         if (replicas == 2) {
-            try std.testing.expectEqual(actual.nack_prepare, 1);
+            try std.testing.expectEqual(1, actual.nack_prepare);
         } else {
-            try std.testing.expectEqual(actual.nack_prepare, actual.view_change);
+            try std.testing.expectEqual(actual.view_change, actual.nack_prepare);
         }
     }
 }


### PR DESCRIPTION
Ensure correct parameter order for all files `src/*.zig` and `src/cdc/**.zig`