### PR TITLE
CI: Run actions with Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   GH_TOKEN: ${{ github.token }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Remove once this is the default (June 2nd, 2026).
 
 jobs:
   smoke:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ permissions: {}
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Remove once this is the default (June 2nd, 2026).
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -13,6 +13,9 @@ on:
     # in systems we do not control.
     - cron: 0 */6 * * *
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Remove once this is the default (June 2nd, 2026).
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
All of our CI jobs ([e.g.](https://github.com/tigerbeetle/tigerbeetle/actions/runs/24933259325)) have warnings like:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Let's upgrade early to fix the warnings and find any breakage ahead of time.