### PR TITLE
CI: Fix flakes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -568,6 +568,7 @@ fn build_ci_step(
     const argv = .{ b.graph.zig_exe, "build" } ++ command;
     const system_command = b.addSystemCommand(&argv);
     const name = std.mem.join(b.allocator, " ", &command) catch @panic("OOM");
+    system_command.max_stdio_size = 128 * MiB; // Prevent error.StreamTooLong.
     system_command.setName(name);
     hide_stderr(system_command);
     step_ci.dependOn(&system_command.step);

--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -662,7 +662,7 @@ public class IntegrationTests
         // We need to wait 1s for the server to expire the transfer, however the
         // server can pulse the expiry operation anytime after the timeout,
         // so adding an extra delay to avoid flaky tests.
-        const long EXTRA_WAIT_TIME = 250;
+        const long EXTRA_WAIT_TIME = 500;
         Thread.Sleep(TimeSpan.FromSeconds(transfer.Timeout)
             .Add(TimeSpan.FromMilliseconds(EXTRA_WAIT_TIME)));
 

--- a/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/IntegrationTest.java
@@ -702,7 +702,7 @@ public class IntegrationTest {
         // so adding an extra delay to avoid flaky tests.
         final var timeout_ms = TimeUnit.SECONDS.toMillis(lookupTransfers.getTimeout());
         final var currentMilis = System.currentTimeMillis();
-        final var extra_wait_time = 250L;
+        final var extra_wait_time = 500L;
         Thread.sleep(timeout_ms + extra_wait_time);
         assertTrue(System.currentTimeMillis() - currentMilis > timeout_ms);
 

--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -447,7 +447,7 @@ test('cannot void an expired transfer', async (): Promise<void> => {
   // server can pulse the expiry operation anytime after the timeout,
   // so adding an extra delay to avoid flaky tests.
   // TODO: Use `await setTimeout(1000)` when upgrade to Node.js > 15.
-  const extra_wait_time = 250;
+  const extra_wait_time = 500;
   await new Promise(_ => setTimeout(_, (transfer.timeout * 1000) + extra_wait_time));
 
   // Looking up the accounts again for the updated balance.

--- a/src/clients/python/tests/test_basic.py
+++ b/src/clients/python/tests/test_basic.py
@@ -379,7 +379,7 @@ def test_cannot_void_an_expired_transfer(client):
     # We need to wait 1s for the server to expire the transfer, however the
     # server can pulse the expiry operation anytime after the timeout,
     # so adding an extra delay to avoid flaky tests.
-    extra_wait_time = 0.25
+    extra_wait_time = 0.50
     time.sleep(transfer.timeout + extra_wait_time)
 
     # Looking up the accounts again for the updated balance.


### PR DESCRIPTION
### Python client test flake

This test flakes occasionally:

```
        assert accounts[0].credits_posted == 150
>       assert accounts[0].credits_pending == 0
E       assert 50 == 0
E        +  where 50 = Account(id=17, debits_pending=0, debits_posted=0, credits_pending=50, credits_posted=150, user_data_128=0, user_data_64=0, user_data_32=0, ledger=1, code=718, flags=<AccountFlags.NONE: 0>, timestamp=1776424280634614101).credits_pending

tests\test_basic.py:389: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_basic.py::test_cannot_void_an_expired_transfer - assert 50 == 0
 +  where 50 = Account(id=17, debits_pending=0, debits_posted=0, credits_pending=50, credits_posted=150, user_data_128=0, user_data_64=0, user_data_32=0, ledger=1, code=718, flags=<AccountFlags.NONE: 0>, timestamp=1776424280634614101).credits_pending
======================== 1 failed, 26 passed in 31.02s ========================
```

### `StreamTooLong` flake

Trying to fix the CI flake:
```
ci
+- test failure
error: failed to spawn and capture stdio from /home/runner/work/tigerbeetle/tigerbeetle/zig/zig: StreamTooLong
Build Summary: 7/9 steps succeeded; 1 failed
ci transitive failure
+- test failure
error: the following build command failed with exit code 1:
/home/runner/work/tigerbeetle/tigerbeetle/.zig-cache/o/b12417ecf22664ef309502a6fedc5ff8/build /home/runner/work/tigerbeetle/tigerbeetle/zig/zig zig/lib /home/runner/work/tigerbeetle/tigerbeetle /home/runner/work/tigerbeetle/tigerbeetle/.zig-cache /home/runner/.cache/zig --seed 0x32614276 -Zb77d5a531da6f3ba ci -- test
```

Default value was 10MiB (see `Build/Step/Run.zig`).

I suspect that the `StreamTooLong` is merely concealing a different flaky failure. But having the logs will help with tracking that down.