### PR TITLE
release validation fixes

### DIFF
--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -159,7 +159,23 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         }
     }
 
-    try shell.unzip_executable("tigerbeetle-x86_64-linux.zip", "tigerbeetle");
+    const artifact_host = switch (builtin.os.tag) {
+        .linux => switch (builtin.cpu.arch) {
+            .aarch64 => "tigerbeetle-aarch64-linux.zip",
+            .x86_64 => "tigerbeetle-x86_64-linux.zip",
+            else => std.debug.panic("unsupported arch {}", .{builtin.os.arch}),
+        },
+        .macos => switch (builtin.cpu.arch) {
+            .aarch64, .x86_64 => "tigerbeetle-universal-macos.zip",
+            else => std.debug.panic("unsupported arch {}", .{builtin.os.arch}),
+        },
+        .windows => switch (builtin.cpu.arch) {
+            .x86_64 => "tigerbeetle-x86_64-windows.zip",
+            else => std.debug.panic("unsupported arch {}", .{builtin.os.arch}),
+        },
+        else => std.debug.panic("unsupported os {}", .{builtin.os.tag}),
+    };
+    try shell.unzip_executable(artifact_host, "tigerbeetle");
 
     const version = try shell.exec_stdout("./tigerbeetle version --verbose", .{});
     assert(std.mem.indexOf(u8, version, tag) != null);

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -110,6 +110,7 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
 
     if (builtin.os.tag != .linux) {
         log.warn("skip release verification for platforms other than Linux", .{});
+        return;
     }
 
     // Note: when updating the list of artifacts, don't forget to check for any external links.

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -294,6 +294,8 @@ fn build_tigerbeetle_target(
         .tag_multiversion = info.tag_multiversion,
     });
 
+    const linux_aarch64 = comptime std.mem.eql(u8, target, "aarch64-linux");
+    const linux_x86_64 = comptime std.mem.eql(u8, target, "x86_64-linux");
     const windows = comptime std.mem.eql(u8, target, "x86_64-windows");
     const macos = comptime std.mem.eql(u8, target, "aarch64-macos");
 
@@ -303,7 +305,8 @@ fn build_tigerbeetle_target(
         (if (debug) "-debug" else "") ++
         ".zip";
 
-    if ((std.mem.eql(u8, target, "x86_64-linux") and builtin.target.os.tag == .linux) or
+    if ((linux_aarch64 and builtin.target.os.tag == .linux and builtin.cpu.arch == .aarch64) or
+        (linux_x86_64 and builtin.target.os.tag == .linux and builtin.cpu.arch == .x86_64) or
         (macos and builtin.target.os.tag == .macos) or
         (windows and builtin.target.os.tag == .windows))
     {


### PR DESCRIPTION
Fixes a couple of things I ran into while trying the validate release CI step locally. First tried running on my Mac where I wasn't able to get reproducible server executables (differences in zip files and tigerbeetle binary). Then I tried an ARM64 Linux VM where I got reproducible release artifacts.