### PR TITLE
CI: Investigate devhub flake

### DIFF
--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -314,8 +314,11 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
             .sha = cli_args.sha,
             .template = "{{range .}}{{.startedAt}} {{.updatedAt}}{{end}}",
         });
-        const iso8601_started_at, const iso8601_updated_at =
-            stdx.cut(times_gh, " ") orelse break :blk null;
+        const iso8601_started_at, const iso8601_updated_at = stdx.cut(times_gh, " ") orelse {
+            log.err("error parsing run list", .{});
+            log.err("output: {s}", .{times_gh});
+            break :blk null;
+        };
 
         const epoch_started_at = try shell.iso8601_to_timestamp_seconds(iso8601_started_at);
         const epoch_updated_at = try shell.iso8601_to_timestamp_seconds(iso8601_updated_at);

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -482,6 +482,8 @@ pub const Supervisor = struct {
     pub fn replica_reformat(supervisor: *Supervisor, replica_index: u8) !void {
         assert(supervisor.replicas[replica_index].state == .terminated);
 
+        log.info("{}: reformatting replica", .{replica_index});
+
         supervisor.shell.cwd.deleteFile(supervisor.replica_datafiles[replica_index]) catch |err| {
             log.err("{}: failed deleting datafile: {}", .{ replica_index, err });
             return err;


### PR DESCRIPTION
Devhub occasionally flakes on `main` with:

```
thread 2934 panic: attempt to use null value
/home/runner/work/tigerbeetle/tigerbeetle/src/scripts/devhub.zig:342:79: 0x1406107 in devhub_metrics (scripts)
            .{ .name = "ci pipeline duration", .value = ci_pipeline_duration_s.?, .unit = "s" },
                                                                              ^
/home/runner/work/tigerbeetle/tigerbeetle/src/scripts/devhub.zig:49:23: 0x140c66f in main (scripts)
    try devhub_metrics(shell, cli_args);
                      ^
/home/runner/work/tigerbeetle/tigerbeetle/src/scripts.zig:101:49: 0x143ea4e in main (scripts)
        .devhub => |args_devhub| try devhub.main(shell, gpa, args_devhub),
                                                ^
```

It seems that sometimes `gh run list` itself flakes -- return exit code `0` but invalid output. (I'm guessing it prints nothing at all, since there is apparently no space in the output.) Adding logging to confirm.

---

Also add a completely unrelated log line to vortex.