### PR TITLE
CI: Disable actions/cache on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
         run: pip install build hatch pytest 'mypy<=1.18.2'
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        # actions/cache (as of v5.0.5) routinely flakes under windows -- it just prints
+        # "Cache hit for: Windows-X64-(hash)" and then exits with no other info.
+        if: matrix.os != 'windows-latest'
         with:
           path: ./zig/cache
           key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./zig/download.sh') }}


### PR DESCRIPTION
We routinely see flakes on windows caused by the actions cache -- it prints something like:
```
Cache hit for: Windows-X64-ce2b5ce6b8b4da3f5d425e87d428019697e96c73077c33e303063b39912ac07c
```
and then fails with no information. ([e.g.](https://github.com/tigerbeetle/tigerbeetle/actions/runs/25067830432/job/73439679933))

I have checked `actions/cache`'s GH issues and didn't see any that match this.

For the time being lets just turn cache off on Windows -- better to be a little slower rather than randomly failing.