### PR TITLE
metric: add object cache fill percentage.

### DIFF
--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -146,6 +146,21 @@ pub fn CacheMapType(
                 self.stash.getKeyPtr(tombstone_from_key(key));
         }
 
+        pub fn fill_percent(self: *const CacheMap) u8 {
+            const cache_value_count = if (self.cache) |*cache|
+                cache.metrics.value_count
+            else
+                return 0;
+            assert(self.options.cache_value_count_max > 0);
+
+            const percent = @divFloor(
+                cache_value_count * 100,
+                self.options.cache_value_count_max,
+            );
+            assert(percent <= 100);
+            return @intCast(percent);
+        }
+
         pub fn upsert(self: *CacheMap, value: *const Value) void {
             const old_value_maybe = self.fetch_upsert(value);
 
@@ -361,7 +376,13 @@ test "cache_map: unit" {
     });
     defer cache_map.deinit(allocator);
 
+    try testing.expectEqual(@as(u8, 0), cache_map.fill_percent());
+
     cache_map.upsert(&.{ .key = 1, .value = 1, .tombstone = false });
+    try testing.expectEqual(
+        @as(u8, @intCast(@divFloor(100, cache_map.options.cache_value_count_max))),
+        cache_map.fill_percent(),
+    );
     try testing.expectEqual(
         TestTable.Value{ .key = 1, .value = 1, .tombstone = false },
         cache_map.get(1).?.*,

--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -146,19 +146,15 @@ pub fn CacheMapType(
                 self.stash.getKeyPtr(tombstone_from_key(key));
         }
 
-        pub fn fill_percent(self: *const CacheMap) u8 {
-            const cache_value_count = if (self.cache) |*cache|
+        pub fn cache_entries(self: *const CacheMap) u64 {
+            return if (self.cache) |*cache|
                 cache.metrics.value_count
             else
-                return 0;
-            assert(self.options.cache_value_count_max > 0);
+                0;
+        }
 
-            const percent = @divFloor(
-                cache_value_count * 100,
-                self.options.cache_value_count_max,
-            );
-            assert(percent <= 100);
-            return @intCast(percent);
+        pub fn cache_entries_max(self: *const CacheMap) u64 {
+            return self.options.cache_value_count_max;
         }
 
         pub fn upsert(self: *CacheMap, value: *const Value) void {
@@ -376,13 +372,14 @@ test "cache_map: unit" {
     });
     defer cache_map.deinit(allocator);
 
-    try testing.expectEqual(@as(u8, 0), cache_map.fill_percent());
+    try testing.expectEqual(@as(u64, 0), cache_map.cache_entries());
+    try testing.expectEqual(
+        @as(u64, cache_map.options.cache_value_count_max),
+        cache_map.cache_entries_max(),
+    );
 
     cache_map.upsert(&.{ .key = 1, .value = 1, .tombstone = false });
-    try testing.expectEqual(
-        @as(u8, @intCast(@divFloor(100, cache_map.options.cache_value_count_max))),
-        cache_map.fill_percent(),
-    );
+    try testing.expectEqual(@as(u64, 1), cache_map.cache_entries());
     try testing.expectEqual(
         TestTable.Value{ .key = 1, .value = 1, .tombstone = false },
         cache_map.get(1).?.*,

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -1462,6 +1462,31 @@ pub fn GrooveType(
                 if (compaction_beat == constants.lsm_compaction_ops - 1) {
                     groove.objects_cache.compact();
                 }
+
+                const Trace = @TypeOf(groove.grid.trace.*);
+                const GrooveMetric = @FieldType(
+                    @FieldType(Trace.EventMetric, "lsm_object_cache_entries"),
+                    "groove",
+                );
+                const maybe_groove_metric = comptime std.meta.stringToEnum(
+                    GrooveMetric,
+                    ObjectTree.tree_name(),
+                );
+
+                if (comptime maybe_groove_metric) |groove_metric| {
+                    groove.grid.trace.gauge(
+                        .{ .lsm_object_cache_entries = .{
+                            .groove = groove_metric,
+                        } },
+                        groove.objects_cache.cache_entries(),
+                    );
+                    groove.grid.trace.gauge(
+                        .{ .lsm_object_cache_entries_max = .{
+                            .groove = groove_metric,
+                        } },
+                        groove.objects_cache.cache_entries_max(),
+                    );
+                }
             }
         }
 

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -1463,30 +1463,18 @@ pub fn GrooveType(
                     groove.objects_cache.compact();
                 }
 
-                const Trace = @TypeOf(groove.grid.trace.*);
-                const GrooveMetric = @FieldType(
-                    @FieldType(Trace.EventMetric, "lsm_object_cache_entries"),
-                    "groove",
+                groove.grid.trace.gauge(
+                    .{ .lsm_object_cache_entries = .{
+                        .groove = @enumFromInt(groove_options.ids.timestamp),
+                    } },
+                    groove.objects_cache.cache_entries(),
                 );
-                const maybe_groove_metric = comptime std.meta.stringToEnum(
-                    GrooveMetric,
-                    ObjectTree.tree_name(),
+                groove.grid.trace.gauge(
+                    .{ .lsm_object_cache_entries_max = .{
+                        .groove = @enumFromInt(groove_options.ids.timestamp),
+                    } },
+                    groove.objects_cache.cache_entries_max(),
                 );
-
-                if (comptime maybe_groove_metric) |groove_metric| {
-                    groove.grid.trace.gauge(
-                        .{ .lsm_object_cache_entries = .{
-                            .groove = groove_metric,
-                        } },
-                        groove.objects_cache.cache_entries(),
-                    );
-                    groove.grid.trace.gauge(
-                        .{ .lsm_object_cache_entries_max = .{
-                            .groove = groove_metric,
-                        } },
-                        groove.objects_cache.cache_entries_max(),
-                    );
-                }
             }
         }
 

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -1463,18 +1463,30 @@ pub fn GrooveType(
                     groove.objects_cache.compact();
                 }
 
-                groove.grid.trace.gauge(
-                    .{ .lsm_object_cache_entries = .{
-                        .groove = @enumFromInt(groove_options.ids.timestamp),
-                    } },
-                    groove.objects_cache.cache_entries(),
+                const Trace = @TypeOf(groove.grid.trace.*);
+                const GrooveMetric = @FieldType(
+                    @FieldType(Trace.EventMetric, "lsm_object_cache_entries"),
+                    "groove",
                 );
-                groove.grid.trace.gauge(
-                    .{ .lsm_object_cache_entries_max = .{
-                        .groove = @enumFromInt(groove_options.ids.timestamp),
-                    } },
-                    groove.objects_cache.cache_entries_max(),
+                const maybe_groove_metric = comptime std.meta.stringToEnum(
+                    GrooveMetric,
+                    ObjectTree.tree_name(),
                 );
+
+                if (comptime maybe_groove_metric) |groove_metric| {
+                    groove.grid.trace.gauge(
+                        .{ .lsm_object_cache_entries = .{
+                            .groove = groove_metric,
+                        } },
+                        groove.objects_cache.cache_entries(),
+                    );
+                    groove.grid.trace.gauge(
+                        .{ .lsm_object_cache_entries_max = .{
+                            .groove = groove_metric,
+                        } },
+                        groove.objects_cache.cache_entries_max(),
+                    );
+                }
             }
         }
 

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -24,6 +24,7 @@ pub const Layout = struct {
 const Metrics = struct {
     hits: u64 = 0,
     misses: u64 = 0,
+    value_count: u64 = 0,
 };
 
 /// Each Key is associated with a set of n consecutive ways (or slots) that may contain the Value.
@@ -251,6 +252,7 @@ pub fn SetAssociativeCacheType(
             const removed: Value = set.values[way];
             self.counts.set(set.offset + way, 0);
             set.values[way] = undefined;
+            self.metrics.value_count -= 1;
 
             return removed;
         }
@@ -350,6 +352,7 @@ pub fn SetAssociativeCacheType(
             set.values[way] = value.*;
             self.counts.set(set.offset + way, 1);
             self.clocks.set(clock_index, way +% 1);
+            if (evicted == null) self.metrics.value_count += 1;
 
             return .{
                 .index = set.offset + way,
@@ -459,6 +462,7 @@ fn set_associative_cache_test(
             for (sac.tags) |tag| try testing.expectEqual(@as(SAC.Tag, 0), tag);
             for (sac.counts.words) |word| try testing.expectEqual(@as(u64, 0), word);
             for (sac.clocks.words) |word| try testing.expectEqual(@as(u64, 0), word);
+            try expectEqual(@as(u64, 0), sac.metrics.value_count);
 
             // Fill up the first set entirely.
             {
@@ -473,6 +477,7 @@ fn set_associative_cache_test(
                     try expect(sac.counts.get(i) == 2);
                 }
                 try expect(sac.clocks.get(0) == 0);
+                try expectEqual(@as(u64, layout.ways), sac.metrics.value_count);
             }
 
             if (log) sac.associate(0).inspect(sac);
@@ -493,6 +498,7 @@ fn set_associative_cache_test(
                         try expect(sac.counts.get(i) == 1);
                     }
                 }
+                try expectEqual(@as(u64, layout.ways), sac.metrics.value_count);
             }
 
             if (log) sac.associate(0).inspect(sac);
@@ -506,6 +512,7 @@ fn set_associative_cache_test(
                 _ = sac.remove(key);
                 try expectEqual(@as(?*Value, null), sac.get(key));
                 try expect(sac.counts.get(5) == 0);
+                try expectEqual(@as(u64, layout.ways - 1), sac.metrics.value_count);
             }
 
             sac.reset();
@@ -513,6 +520,7 @@ fn set_associative_cache_test(
             for (sac.tags) |tag| try testing.expectEqual(@as(SAC.Tag, 0), tag);
             for (sac.counts.words) |word| try testing.expectEqual(@as(u64, 0), word);
             for (sac.clocks.words) |word| try testing.expectEqual(@as(u64, 0), word);
+            try expectEqual(@as(u64, 0), sac.metrics.value_count);
 
             // Fill up the first set entirely, maxing out the count for each slot.
             {
@@ -532,6 +540,7 @@ fn set_associative_cache_test(
                     try expect(sac.counts.get(i) == math.maxInt(SAC.Count));
                 }
                 try expect(sac.clocks.get(0) == 0);
+                try expectEqual(@as(u64, layout.ways), sac.metrics.value_count);
             }
 
             if (log) sac.associate(0).inspect(sac);
@@ -552,6 +561,7 @@ fn set_associative_cache_test(
                         try expect(sac.counts.get(i) == 1);
                     }
                 }
+                try expectEqual(@as(u64, layout.ways), sac.metrics.value_count);
             }
 
             if (log) sac.associate(0).inspect(sac);

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -554,7 +554,8 @@ pub const EventMetric = union(enum) {
     grid_blocks_missing,
     grid_cache_hits,
     grid_cache_misses,
-    lsm_object_cache_fill_percent: struct { groove: GrooveEnum },
+    lsm_object_cache_entries: struct { groove: GrooveEnum },
+    lsm_object_cache_entries_max: struct { groove: GrooveEnum },
     lsm_nodes_free,
     lsm_manifest_block_count,
     metrics_statsd_packets,
@@ -591,7 +592,8 @@ pub const EventMetric = union(enum) {
         .grid_blocks_missing = 1,
         .grid_cache_hits = 1,
         .grid_cache_misses = 1,
-        .lsm_object_cache_fill_percent = enum_count(GrooveEnum),
+        .lsm_object_cache_entries = enum_count(GrooveEnum),
+        .lsm_object_cache_entries_max = enum_count(GrooveEnum),
         .lsm_nodes_free = 1,
         .lsm_manifest_block_count = 1,
         .metrics_statsd_packets = 1,
@@ -637,7 +639,9 @@ pub const EventMetric = union(enum) {
 
                 return slot_bases.get(event.*) + offset;
             },
-            inline .lsm_object_cache_fill_percent => |data| {
+            inline .lsm_object_cache_entries,
+            .lsm_object_cache_entries_max,
+            => |data| {
                 const groove = index_from_enum(data.groove);
                 const offset = groove;
                 assert(offset < slot_limits.get(event.*));
@@ -732,7 +736,10 @@ test "EventMetric slot doesn't have collisions" {
             .value_count_visible => .{ .value_count_visible = .{
                 .tree = g.enum_value(TreeEnum),
             } },
-            .lsm_object_cache_fill_percent => .{ .lsm_object_cache_fill_percent = .{
+            .lsm_object_cache_entries => .{ .lsm_object_cache_entries = .{
+                .groove = g.enum_value(GrooveEnum),
+            } },
+            .lsm_object_cache_entries_max => .{ .lsm_object_cache_entries_max = .{
                 .groove = g.enum_value(GrooveEnum),
             } },
             .compaction_values_physical => .{ .compaction_values_physical = .{

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -58,6 +58,26 @@ const TreeEnum = tree_enum: {
     } });
 };
 
+const GrooveEnum = groove_enum: {
+    const tree_ids = @import("../state_machine.zig").tree_ids;
+    var groove_fields: []const std.builtin.Type.EnumField = &[_]std.builtin.Type.EnumField{};
+
+    for (std.meta.declarations(tree_ids)) |groove_field| {
+        const tree_ids_groove = @field(tree_ids, groove_field.name);
+        groove_fields = groove_fields ++ &[_]std.builtin.Type.EnumField{.{
+            .name = groove_field.name,
+            .value = @field(tree_ids_groove, "timestamp"),
+        }};
+    }
+
+    break :groove_enum @Type(.{ .@"enum" = .{
+        .tag_type = u32,
+        .fields = groove_fields,
+        .decls = &.{},
+        .is_exhaustive = true,
+    } });
+};
+
 /// Returns the count of an exhaustive enum.
 fn enum_count(EnumOrUnion: type) u8 {
     const type_info = @typeInfo(EnumOrUnion);
@@ -534,6 +554,7 @@ pub const EventMetric = union(enum) {
     grid_blocks_missing,
     grid_cache_hits,
     grid_cache_misses,
+    lsm_object_cache_fill_percent: struct { groove: GrooveEnum },
     lsm_nodes_free,
     lsm_manifest_block_count,
     metrics_statsd_packets,
@@ -570,6 +591,7 @@ pub const EventMetric = union(enum) {
         .grid_blocks_missing = 1,
         .grid_cache_hits = 1,
         .grid_cache_misses = 1,
+        .lsm_object_cache_fill_percent = enum_count(GrooveEnum),
         .lsm_nodes_free = 1,
         .lsm_manifest_block_count = 1,
         .metrics_statsd_packets = 1,
@@ -611,6 +633,13 @@ pub const EventMetric = union(enum) {
             => |data| {
                 const tree_id = index_from_enum(data.tree);
                 const offset = tree_id;
+                assert(offset < slot_limits.get(event.*));
+
+                return slot_bases.get(event.*) + offset;
+            },
+            inline .lsm_object_cache_fill_percent => |data| {
+                const groove = index_from_enum(data.groove);
+                const offset = groove;
                 assert(offset < slot_limits.get(event.*));
 
                 return slot_bases.get(event.*) + offset;
@@ -702,6 +731,9 @@ test "EventMetric slot doesn't have collisions" {
             } },
             .value_count_visible => .{ .value_count_visible = .{
                 .tree = g.enum_value(TreeEnum),
+            } },
+            .lsm_object_cache_fill_percent => .{ .lsm_object_cache_fill_percent = .{
+                .groove = g.enum_value(GrooveEnum),
             } },
             .compaction_values_physical => .{ .compaction_values_physical = .{
                 .tree = g.enum_value(TreeEnum),

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3848,6 +3848,29 @@ pub fn ReplicaType(
             self.trace.gauge(.grid_cache_hits, self.grid.cache.metrics.hits);
             self.trace.gauge(.grid_cache_misses, self.grid.cache.metrics.misses);
             self.trace.gauge(.lsm_nodes_free, self.state_machine.forest.node_pool.free.count());
+            inline for (std.meta.fields(StateMachine.Forest.Grooves)) |field| {
+                const Groove = field.type;
+                if (Groove.ObjectsCache != void) {
+                    const GrooveMetric = @TypeOf(@as(
+                        vsr.trace.EventMetric,
+                        undefined,
+                    ).lsm_object_cache_fill_percent.groove);
+                    const groove_metric = comptime std.meta.stringToEnum(
+                        GrooveMetric,
+                        Groove.ObjectTree.tree_name(),
+                    );
+                    if (groove_metric) |groove_metric_unwrapped| {
+                        const groove: *const Groove =
+                            &@field(self.state_machine.forest.grooves, field.name);
+                        self.trace.gauge(
+                            .{ .lsm_object_cache_fill_percent = .{
+                                .groove = groove_metric_unwrapped,
+                            } },
+                            groove.objects_cache.fill_percent(),
+                        );
+                    }
+                }
+            }
             self.trace.gauge(.release, self.release.value);
 
             self.trace.gauge(

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3854,7 +3854,7 @@ pub fn ReplicaType(
                     const GrooveMetric = @TypeOf(@as(
                         vsr.trace.EventMetric,
                         undefined,
-                    ).lsm_object_cache_fill_percent.groove);
+                    ).lsm_object_cache_entries.groove);
                     const groove_metric = comptime std.meta.stringToEnum(
                         GrooveMetric,
                         Groove.ObjectTree.tree_name(),
@@ -3863,10 +3863,16 @@ pub fn ReplicaType(
                         const groove: *const Groove =
                             &@field(self.state_machine.forest.grooves, field.name);
                         self.trace.gauge(
-                            .{ .lsm_object_cache_fill_percent = .{
+                            .{ .lsm_object_cache_entries = .{
                                 .groove = groove_metric_unwrapped,
                             } },
-                            groove.objects_cache.fill_percent(),
+                            groove.objects_cache.cache_entries(),
+                        );
+                        self.trace.gauge(
+                            .{ .lsm_object_cache_entries_max = .{
+                                .groove = groove_metric_unwrapped,
+                            } },
+                            groove.objects_cache.cache_entries_max(),
                         );
                     }
                 }

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -3848,35 +3848,6 @@ pub fn ReplicaType(
             self.trace.gauge(.grid_cache_hits, self.grid.cache.metrics.hits);
             self.trace.gauge(.grid_cache_misses, self.grid.cache.metrics.misses);
             self.trace.gauge(.lsm_nodes_free, self.state_machine.forest.node_pool.free.count());
-            inline for (std.meta.fields(StateMachine.Forest.Grooves)) |field| {
-                const Groove = field.type;
-                if (Groove.ObjectsCache != void) {
-                    const GrooveMetric = @TypeOf(@as(
-                        vsr.trace.EventMetric,
-                        undefined,
-                    ).lsm_object_cache_entries.groove);
-                    const groove_metric = comptime std.meta.stringToEnum(
-                        GrooveMetric,
-                        Groove.ObjectTree.tree_name(),
-                    );
-                    if (groove_metric) |groove_metric_unwrapped| {
-                        const groove: *const Groove =
-                            &@field(self.state_machine.forest.grooves, field.name);
-                        self.trace.gauge(
-                            .{ .lsm_object_cache_entries = .{
-                                .groove = groove_metric_unwrapped,
-                            } },
-                            groove.objects_cache.cache_entries(),
-                        );
-                        self.trace.gauge(
-                            .{ .lsm_object_cache_entries_max = .{
-                                .groove = groove_metric_unwrapped,
-                            } },
-                            groove.objects_cache.cache_entries_max(),
-                        );
-                    }
-                }
-            }
             self.trace.gauge(.release, self.release.value);
 
             self.trace.gauge(


### PR DESCRIPTION
This PR introduces a metric to track memory pressure across our object caches. Cache sizing has a significant impact on performance: when caches are too small, we observe clear degradation. 
The metric is expressed as a percentage of the associative cache's capacity.
A good value is `< 75` to avoid collisions. 