### PR TITLE
Devhub: Show CI flake count, and misc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         # actions/cache (as of v5.0.5) routinely flakes under windows -- it just prints
         # "Cache hit for: Windows-X64-(hash)" and then exits with no other info.
-        if: matrix.os != 'windows-latest'
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}
         with:
           path: ./zig/cache
           key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./zig/download.sh') }}

--- a/docs/internals/releases.md
+++ b/docs/internals/releases.md
@@ -10,7 +10,7 @@ The motivation for specific steps follows after.
 
 ### Friday
 
-1. Open [devhub](https://tigerbeetle.github.io/tigerbeetle/) to check that:
+1. Open [devhub](https://devhub.tigerbeetle.com/) to check that:
    - you are the release manager for the week
    - the VOPR results look reasonable (no failures and a bunch of successful runs for recent
      commits)
@@ -224,7 +224,7 @@ As such:
 ## Release Logistics
 
 Releases are triggered manually, on Monday. Default release rotation is on the
-devhub: <https://tigerbeetle.github.io/tigerbeetle/>.
+devhub: <https://devhub.tigerbeetle.com/>.
 
 The middle name is the default release manager for the _current_ week. They should execute [Release
 Manager Algorithm](#release-manager-algorithm) on Monday. If the release manager isn't available on

--- a/src/devhub/devhub.js
+++ b/src/devhub/devhub.js
@@ -53,16 +53,28 @@ function main_release_rotation() {
 }
 
 async function main_seeds() {
+  const duration_week = 1000 * 60 * 60 * 24 * 7;
+  const earlier = new Date(Date.now() - duration_week);
+
   const data_url =
     "https://raw.githubusercontent.com/tigerbeetle/devhubdb/main/fuzzing/data.json";
   const issues_url =
     "https://api.github.com/repos/tigerbeetle/tigerbeetle/issues?per_page=200";
   const logs_base =
     "https://raw.githubusercontent.com/tigerbeetle/devhubdb/main/";
+  const flakes_url =
+    `https://api.github.com/repos/tigerbeetle/tigerbeetle/actions/runs?${new URLSearchParams({
+      branch: 'main',
+      per_page: 100,
+      created: `>=${earlier.toISOString().split('T')[0]}`,
+      status: 'failure',
+      exclude_pull_requests: 'true',
+    })}`;
 
-  const [records, issues] = await Promise.all([
+  const [records, issues, flakes] = await Promise.all([
     fetch_json(data_url),
     fetch_json(issues_url),
+    fetch_json(flakes_url),
   ]);
 
   const pulls = issues.filter((issue) => issue.pull_request);
@@ -80,6 +92,11 @@ async function main_seeds() {
     document.querySelector("#untriaged-issues-count").classList.add(
       "untriaged",
     );
+  }
+
+  document.querySelector("#flakes-count").innerText = flakes.total_count;
+  if (flakes.total_count) {
+    document.querySelector("#flakes-count").classList.add("untriaged");
   }
 
   // Filtering:

--- a/src/devhub/index.html
+++ b/src/devhub/index.html
@@ -47,6 +47,8 @@
               title="Let's keep the number of untriaged issues at zero. Triaged means that we looked at the issue, responded and labeled the issue as triaged.">Issue
               triage <span class="badge" id="untriaged-issues-count">0</span></a></p>
           <p><a href="./coverage/index.html">Coverage</a></p>
+          <p><a href="https://github.com/tigerbeetle/tigerbeetle/actions?query=branch%3Amain+-is%3Asuccess">Flakes
+              <span class="badge" id="flakes-count">0</span></a></p>
         </div>
       </section>
     </section>

--- a/src/devhub/style.css
+++ b/src/devhub/style.css
@@ -79,6 +79,10 @@ h3 {
     padding: 1px 6px;
     color: var(--gray-1);
     font-weight: bold;
+
+    &.untriaged {
+        background-color: var(--red-10);
+    }
 }
 
 nav {
@@ -133,10 +137,6 @@ section#top {
         p {
             line-height: 24px;
         }
-    }
-
-    #untriaged-issues-count.untriaged {
-        background-color: var(--red-10);
     }
 }
 

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -396,13 +396,13 @@ fn get_measurement(
 }
 
 fn upload_run(shell: *Shell, batch: *const MetricBatch) !void {
-    const token = try shell.env_get("DEVHUBDB_PAT");
+    const token = shell.env_get_option("DEVHUBDB_PAT");
     try shell.exec(
         \\git clone --single-branch --depth 1
         \\  https://oauth2:{token}@github.com/tigerbeetle/devhubdb.git
         \\  devhubdb
     , .{
-        .token = token,
+        .token = token orelse "",
     });
 
     try shell.pushd("./devhubdb");
@@ -426,11 +426,15 @@ fn upload_run(shell: *Shell, batch: *const MetricBatch) !void {
         try shell.exec("git add ./devhub/data.json", .{});
         try shell.git_env_setup(.{ .use_hostname = false });
         try shell.exec("git commit -m 📈", .{});
-        if (shell.exec("git push", .{})) {
-            log.info("metrics uploaded", .{});
-            break;
-        } else |_| {
-            log.info("conflict, retrying", .{});
+        if (token) |_| {
+            if (shell.exec("git push", .{})) {
+                log.info("metrics uploaded", .{});
+                break;
+            } else |_| {
+                log.info("conflict, retrying", .{});
+            }
+        } else {
+            return error.NoToken;
         }
     } else {
         log.err("can't push new data to devhub", .{});

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -1,4 +1,4 @@
-//! Runs a set of macro-benchmarks whose result is displayed at <https://tigerbeetle.github.io>.
+//! Runs a set of macro-benchmarks whose result is displayed at <https://devhub.tigerbeetle.com/>.
 //!
 //! Specifically:
 //!


### PR DESCRIPTION
Misc CI-adjacent improvements:

- Allow `actions/cache` to fail on windows. This is a follow-up to https://github.com/tigerbeetle/tigerbeetle/pull/3678 -- we can still use the cache, just ignore it if it fails.
- Fix broken devhub URL's in docs.
- In devhub zig script, clone+mutate devhubdb even when no github token is provided. We do the same in CFO, to make  debugging easier.
- In devhub, show the number of recent (<1 week old) CI flakes on main.
  - Flakes are counted by grabbing failing CI runs from `main`. Since we require passing CI before merging into `main`, via merge queue, any failures are on main are almost certainly flaky tests.
  - I initially implemented this in `devhub.zig`, to fetch detailed data on failing jobs to push to devhubdb. But I think we don't need all that; a count is sufficient and for more detail we can just check github via the link.

<img width="170" height="163" alt="2026-05-01T11:09:07,600153823-06:00" src="https://github.com/user-attachments/assets/ca87ce76-b48b-407c-af94-1799bb2d5345" />
