### PR TITLE
Enable assertions for Java client samples and fix errors

### DIFF
--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -33,6 +33,7 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         errdefer tmp_beetle.log_stderr();
 
         try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
+        try shell.env.put("MAVEN_OPTS", "-ea");
         try shell.exec(
             \\mvn --batch-mode --file pom.xml --quiet
             \\  package exec:java

--- a/src/clients/java/samples/basic/README.md
+++ b/src/clients/java/samples/basic/README.md
@@ -31,6 +31,12 @@ address of the TigerBeetle server you started.
 
 ## Run this sample
 
+First, you must enable assertions through `MAVEN_OPTS` variable:
+
+```console
+export MAVEN_OPTS="-ea"
+```
+
 Now you can run this sample:
 
 ```console

--- a/src/clients/java/samples/two-phase-many/README.md
+++ b/src/clients/java/samples/two-phase-many/README.md
@@ -31,6 +31,12 @@ address of the TigerBeetle server you started.
 
 ## Run this sample
 
+First, you must enable assertions through `MAVEN_OPTS` variable:
+
+```console
+export MAVEN_OPTS="-ea"
+```
+
 Now you can run this sample:
 
 ```console

--- a/src/clients/java/samples/two-phase-many/src/main/java/Main.java
+++ b/src/clients/java/samples/two-phase-many/src/main/java/Main.java
@@ -45,7 +45,7 @@ public final class Main {
             transfers.setCreditAccountId(2);
             transfers.setLedger(1);
             transfers.setCode(1);
-            transfers.setAmount(500);
+            transfers.setAmount(100);
             transfers.setFlags(TransferFlags.PENDING);
 
             transfers.add();
@@ -110,13 +110,13 @@ public final class Main {
                         && accounts.getId(UInt128.MostSignificant) == 0) {
                     assert accounts.getDebitsPosted().intValueExact() == 0;
                     assert accounts.getCreditsPosted().intValueExact() == 0;
-                    assert accounts.getDebitsPending().intValueExact() == 500;
+                    assert accounts.getDebitsPending().intValueExact() == 1500;
                     assert accounts.getCreditsPending().intValueExact() == 0;
                 } else if (Arrays.equals(accounts.getId(), UInt128.asBytes(2))) {
                     assert accounts.getDebitsPosted().intValueExact() == 0;
                     assert accounts.getCreditsPosted().intValueExact() == 0;
                     assert accounts.getDebitsPending().intValueExact() == 0;
-                    assert accounts.getCreditsPending().intValueExact() == 500;
+                    assert accounts.getCreditsPending().intValueExact() == 1500;
                 } else {
                     System.err.printf("Unexpected account: %s\n",
                             UInt128.asBigInteger(accounts.getId()).toString());
@@ -323,13 +323,13 @@ public final class Main {
             // Create a 10th transfer posting the 5th transfer.
             transfers = new TransferBatch(1);
             transfers.add();
-            transfers.setId(6);
-            transfers.setPendingId(1);
+            transfers.setId(10);
+            transfers.setPendingId(5);
             transfers.setDebitAccountId(1);
             transfers.setCreditAccountId(2);
             transfers.setLedger(1);
             transfers.setCode(1);
-            transfers.setAmount(100);
+            transfers.setAmount(500);
             transfers.setFlags(TransferFlags.POST_PENDING_TRANSFER);
 
             transferResults = client.createTransfers(transfers);

--- a/src/clients/java/samples/two-phase/README.md
+++ b/src/clients/java/samples/two-phase/README.md
@@ -31,6 +31,12 @@ address of the TigerBeetle server you started.
 
 ## Run this sample
 
+First, you must enable assertions through `MAVEN_OPTS` variable:
+
+```console
+export MAVEN_OPTS="-ea"
+```
+
 Now you can run this sample:
 
 ```console

--- a/src/clients/java/samples/two-phase/src/main/java/Main.java
+++ b/src/clients/java/samples/two-phase/src/main/java/Main.java
@@ -130,7 +130,7 @@ public final class Main {
                     assert accounts.getCreditsPosted().intValueExact() == 0;
                     assert accounts.getDebitsPending().intValueExact() == 0;
                     assert accounts.getCreditsPending().intValueExact() == 0;
-                } else if (accounts.getId(UInt128.LeastSignificant) == 1
+                } else if (accounts.getId(UInt128.LeastSignificant) == 2
                         && accounts.getId(UInt128.MostSignificant) == 0) {
                     assert accounts.getDebitsPosted().intValueExact() == 0;
                     assert accounts.getCreditsPosted().intValueExact() == 500;


### PR DESCRIPTION
Hi,

First of all, thank you for your great product.

As stated in the [Java documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/language/assert.html), assertions aren't enabled by default in Java

> By default, assertions are disabled at runtime. [...] To enable assertions [...], use the `-enableassertions`, or `-ea`, switch. 

After enabling assertions, two samples have errors: `two-phase` and `two-phase-many`

In this PR, I'm doing three things:

- Enabling assertions in Java for CI
- Fixing errors in `two-phase` and `two-phase-many`
- Adding documentation on how to enable assertions on the `README.md` files

Cheers