### PR TITLE
tighten file permissions

### DIFF
--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -504,7 +504,7 @@ fn build_multiversion_body(shell: *Shell, options: struct {
             .mode = .write_only,
         });
         defer old_current_release_fd.close();
-        try old_current_release_fd.chmod(0o777);
+        try old_current_release_fd.chmod(0o755);
     }
 
     // It's important to verify the previous current_release checksum - it can't be verified at
@@ -559,7 +559,7 @@ fn build_multiversion_body(shell: *Shell, options: struct {
             multiversion.Release{ .value = past_release },
             @tagName(options.arch),
         });
-        const mode_exec = if (builtin.os.tag == .windows) 0 else 0o777;
+        const mode_exec = if (builtin.os.tag == .windows) 0 else 0o755;
         try shell.cwd.writeFile(.{
             .sub_path = past_name,
             .data = past_binary_contents[arch_offsets.body_offset..][past_offset..][0..past_size],
@@ -677,7 +677,7 @@ fn macos_universal_binary_build(
 
     var output_file = try shell.project_root.createFile(output_path, .{
         .exclusive = true,
-        .mode = if (builtin.target.os.tag == .windows) 0 else 0o777,
+        .mode = if (builtin.target.os.tag == .windows) 0 else 0o755,
     });
     defer output_file.close();
 

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -1005,7 +1005,7 @@ pub const IO = struct {
             .format => {
                 flags.CREAT = true;
                 flags.EXCL = true;
-                mode = 0o666;
+                mode = 0o600;
                 log.info("creating \"{s}\"...", .{relative_path});
             },
             .open, .inspect => {

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -1580,7 +1580,7 @@ pub const IO = struct {
                     .format => {
                         flags.CREAT = true;
                         flags.EXCL = true;
-                        mode = 0o666;
+                        mode = 0o600;
                         log.info("creating \"{s}\"...", .{relative_path});
                     },
                     .open, .inspect => {
@@ -1786,7 +1786,7 @@ pub const IO = struct {
         const path: [:0]const u8 = "fs_supports_direct_io-" ++ cookie ++ "";
         const dir = std.fs.Dir{ .fd = dir_fd };
         const flags: posix.O = .{ .CLOEXEC = true, .CREAT = true, .TRUNC = true };
-        const fd = try posix.openatZ(dir_fd, path, flags, 0o666);
+        const fd = try posix.openatZ(dir_fd, path, flags, 0o600);
         defer posix.close(fd);
         defer dir.deleteFile(path) catch {};
 

--- a/src/multiversion.zig
+++ b/src/multiversion.zig
@@ -763,7 +763,7 @@ pub const MultiversionOS = struct {
             },
 
             .macos, .windows => blk: {
-                const mode = if (builtin.target.os.tag == .macos) 0o777 else 0;
+                const mode = if (builtin.target.os.tag == .macos) 0o755 else 0;
                 const file = std.fs.createFileAbsolute(
                     target_path,
                     .{ .read = true, .truncate = true, .mode = mode },

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -253,7 +253,7 @@ pub fn file_make_executable(shell: *Shell, path: []const u8) !void {
         const fd = try shell.cwd.openFile(path, .{ .mode = .read_write });
         defer fd.close();
 
-        try fd.chmod(0o777);
+        try fd.chmod(0o755);
     }
 }
 


### PR DESCRIPTION
There's absoletly no reason for us to create world-writable files. We actually can't, because of default umask, so let's not even ask for that.