### PR TITLE
io: refactor Stats

### DIFF
--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -5,6 +5,8 @@ const posix = std.posix;
 
 const stdx = @import("stdx");
 
+const Tracer = @import("../trace.zig").Tracer;
+
 const assert = std.debug.assert;
 
 const is_linux = builtin.target.os.tag == .linux;
@@ -157,33 +159,27 @@ pub fn aof_blocking_open(dir_fd: posix.fd_t, path: []const u8) !posix.fd_t {
 }
 
 pub const Stats = struct {
-    const Tracer = @import("../trace.zig").Tracer;
+    tracer: ?*Tracer = null,
+
+    total: Timings = .{},
+    window: Timings = .{},
+
     const Timings = struct {
         time_callbacks: stdx.Duration = .ms(0),
         time_run_for_ns: stdx.Duration = .ms(0),
 
-        pub fn time_since(now: Timings, earlier: Timings) Timings {
-            assert(now.time_callbacks.ns >= earlier.time_callbacks.ns);
-            assert(now.time_run_for_ns.ns >= earlier.time_run_for_ns.ns);
-
-            return .{
-                .time_callbacks = now.time_callbacks.subtract(earlier.time_callbacks),
-                .time_run_for_ns = now.time_run_for_ns.subtract(earlier.time_run_for_ns),
-            };
+        pub fn add(total: *Timings, increment: Timings) void {
+            total.time_callbacks.ns +|= increment.time_callbacks.ns;
+            total.time_run_for_ns.ns +|= increment.time_run_for_ns.ns;
         }
     };
 
-    now: Timings = .{},
-    earlier: Timings = .{},
-    tracer: ?*Tracer = null,
-
     pub fn trace(stats: *Stats) void {
         if (stats.tracer) |tracer| {
-            const timings_delta = stats.now.time_since(stats.earlier);
-            stats.earlier = stats.now;
-
-            tracer.timing(.loop_run_for_ns, timings_delta.time_run_for_ns);
-            tracer.timing(.loop_callbacks, timings_delta.time_callbacks);
+            tracer.timing(.loop_run_for_ns, stats.window.time_run_for_ns);
+            tracer.timing(.loop_callbacks, stats.window.time_callbacks);
         }
+        stats.total.add(stats.window);
+        stats.window = .{};
     }
 };

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -54,7 +54,7 @@ pub const IO = struct {
         defer self.stats.trace();
 
         var timer = try std.time.Timer.start();
-        defer self.stats.now.time_run_for_ns.ns += timer.read();
+        defer self.stats.window.time_run_for_ns.ns += timer.read();
 
         var timed_out = false;
         var completion: Completion = undefined;
@@ -140,7 +140,7 @@ pub const IO = struct {
         while (completed.pop()) |completion| {
             (completion.callback)(self, completion);
         }
-        self.stats.now.time_callbacks.ns += timer.read();
+        self.stats.window.time_callbacks.ns += timer.read();
     }
 
     fn flush_io(self: *IO, events: []posix.Kevent) usize {

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -124,7 +124,7 @@ pub const IO = struct {
         defer self.stats.trace();
 
         var timer = try std.time.Timer.start();
-        defer self.stats.now.time_run_for_ns.ns += timer.read();
+        defer self.stats.window.time_run_for_ns.ns += timer.read();
 
         // We must use the same clock source used by io_uring (CLOCK_MONOTONIC) since we specify the
         // timeout below as an absolute value. Otherwise, we may deadlock if the clock sources are
@@ -210,7 +210,7 @@ pub const IO = struct {
             }
         }
 
-        self.stats.now.time_callbacks.ns += timer.read();
+        self.stats.window.time_callbacks.ns += timer.read();
 
         // At this point, unqueued could have completions either by 1) those who didn't get an SQE
         // during the popping of unqueued or 2) completion.complete() which start new IO. These

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -57,7 +57,7 @@ pub const IO = struct {
         defer self.stats.trace();
 
         var timer = try std.time.Timer.start();
-        defer self.stats.now.time_run_for_ns.ns += timer.read();
+        defer self.stats.window.time_run_for_ns.ns += timer.read();
 
         const Callback = struct {
             fn on_timeout(
@@ -152,7 +152,7 @@ pub const IO = struct {
                 .completion = completion,
             });
         }
-        self.stats.now.time_callbacks.ns += timer.read();
+        self.stats.window.time_callbacks.ns += timer.read();
     }
 
     fn flush_timeouts(self: *IO) ?u64 {

--- a/src/stdx/time_units.zig
+++ b/src/stdx/time_units.zig
@@ -73,12 +73,6 @@ pub const Duration = struct {
         }
     };
 
-    pub fn subtract(longer: Duration, shorter: Duration) Duration {
-        assert(longer.ns >= shorter.ns);
-        const difference_ns = longer.ns - shorter.ns;
-        return .{ .ns = difference_ns };
-    }
-
     // Human readable format like `1.123s`.
     // NB: this is a lossy operation, durations are rounded to look nice.
     pub fn format(

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -95,6 +95,7 @@
 //!         },
 //!     },
 //!
+const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.trace);
@@ -464,8 +465,9 @@ pub fn timing(tracer: *Tracer, event_timing: EventTiming, duration: Duration) vo
 /// Log warnings for slow timings, to have redundancy with metrics.
 /// Perhaps thresholds should be runtime-configurable in main, but let's simply hard-code for now.
 pub fn timing_warn(tracer: *Tracer, event_timing: EventTiming, duration: Duration) void {
+    const fast = comptime builtin.target.os.tag == .linux and builtin.mode != .Debug;
     const threshold: Duration = switch (event_timing) {
-        .loop_run_for_ns => .ms(50),
+        .loop_run_for_ns => if (fast) .ms(50) else .ms(500),
         else => return,
     };
     if (duration.ns >= threshold.ns) {

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -436,6 +436,8 @@ pub fn emit_metrics(tracer: *Tracer) void {
 pub fn timing(tracer: *Tracer, event_timing: EventTiming, duration: Duration) void {
     const timing_slot = event_timing.slot();
 
+    tracer.timing_warn(event_timing, duration);
+
     if (tracer.events_timing[timing_slot]) |*event_timing_existing| {
         assert(std.meta.eql(event_timing_existing.event, event_timing));
 
@@ -456,6 +458,23 @@ pub fn timing(tracer: *Tracer, event_timing: EventTiming, duration: Duration) vo
                 .count = 1,
             },
         };
+    }
+}
+
+/// Log warnings for slow timings, to have redundancy with metrics.
+/// Perhaps thresholds should be runtime-configurable in main, but let's simply hard-code for now.
+pub fn timing_warn(tracer: *Tracer, event_timing: EventTiming, duration: Duration) void {
+    const threshold: Duration = switch (event_timing) {
+        .loop_run_for_ns => .ms(50),
+        else => return,
+    };
+    if (duration.ns >= threshold.ns) {
+        log.warn("{}: timing: {s} too slow ({} > {})", .{
+            tracer.process_id,
+            @tagName(event_timing),
+            duration,
+            threshold,
+        });
     }
 }
 


### PR DESCRIPTION
This is just moving code around to make it prettier, but I do think it's at least ε-better!

The `subtract` on `Duration` looked sus to me --- you generally want to sutract `Instance`s, and add duration. Looking at how it is used, it's not wrong, but I think the code becomes a bit clearer if we just explicitly track the window, rather than implicitly re-compute it as a difference between two points.

I also moved type declarations after fields, as per TigerStyle, to make data more visible.

I also moved Tracer dependency to be a first "block" of fields. In MatkladStyle, I like to visually separate dependencies you inject (usually pointers and/or vtables) from actual data being stored (values).

Actually, I now don't fully understand why we are keeping `total` at all, we only ever seem to be using window, but I guess no harm in keeping the running total!

I also +| for safety. We probably ain't gona run for 2**64 nanoseconds, but, if someone did decide on 600 year cluster, we might as well make it work!