### PR TITLE
reformat: fix re-entrancy bug

### DIFF
--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -623,8 +623,9 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
             assert(cluster.replica_health[replica_index] == .reformatting);
 
             const reformat = &cluster.replica_reformats[replica_index].?;
-            const result = reformat.done() orelse return;
-            assert(result == .ok);
+            if (reformat.pending()) return;
+
+            reformat.format() catch |err| fatal(.correctness, "reformat: {}", .{err});
 
             reformat.deinit(cluster.allocator);
             cluster.replica_reformats[replica_index] = null;

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -549,16 +549,15 @@ fn command_reformat(
     defer reformatter.deinit(gpa);
 
     reformatter.start();
-    while (reformatter.done() == null) {
+    while (reformatter.pending()) {
         client.tick();
         try io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
     }
-    switch (reformatter.done().?) {
-        .failed => |err| {
-            log.err("{}: error: {s}", .{ args.replica, @errorName(err) });
-            return err;
-        },
-        .ok => log.info("{}: success", .{args.replica}),
+    if (reformatter.format()) {
+        log.info("{}: success", .{args.replica});
+    } else |err| {
+        log.err("{}: error: {s}", .{ args.replica, @errorName(err) });
+        return err;
     }
 }
 

--- a/src/vsr/replica_reformat.zig
+++ b/src/vsr/replica_reformat.zig
@@ -16,7 +16,7 @@
 //!   being lost, and we can't remember any promises we made.
 //! - Likewise, we don't want to go to view + 1 -- if we were the first to collect a EV quorum
 //!   before being lost, we might have sent a JV. Since we don't remember, we must skip past
-//!   `view + 11 to ensure that we don't send a different JV. (We have the invariant that if a
+//!   `view + 1` to ensure that we don't send a different JV. (We have the invariant that if a
 //!   replica sends a JV for a given view, then all JV's it sends for that view will be
 //!   identical.)
 const std = @import("std");
@@ -24,7 +24,7 @@ const assert = std.debug.assert;
 
 const constants = @import("../constants.zig");
 const vsr = @import("../vsr.zig");
-const format = @import("./replica_format.zig").format;
+const replica_format = @import("./replica_format.zig");
 
 const log = std.log.scoped(.reformat);
 
@@ -50,7 +50,7 @@ pub fn ReplicaReformatType(
         storage: *Storage,
 
         requests_done: u32 = 0,
-        result: ?Result = null,
+        safe_view: ?u32 = null,
 
         pub fn init(
             allocator: std.mem.Allocator,
@@ -84,6 +84,27 @@ pub fn ReplicaReformatType(
             reformat.client.register(client_register_callback, user_data);
         }
 
+        pub fn pending(reformat: *const ReplicaReformat) bool {
+            return reformat.safe_view == null;
+        }
+
+        pub fn format(reformat: *ReplicaReformat) !void {
+            assert(reformat.safe_view != null);
+            const safe_view = reformat.safe_view.?;
+            reformat.safe_view = null;
+
+            var options = reformat.options;
+            assert(options.view == null);
+            options.view = safe_view;
+
+            try replica_format.format(
+                Storage,
+                reformat.allocator,
+                reformat.storage,
+                options,
+            );
+        }
+
         fn client_register_callback(
             user_data: u128,
             register_result: *const vsr.RegisterResult,
@@ -91,6 +112,7 @@ pub fn ReplicaReformatType(
             _ = register_result;
             const reformat: *ReplicaReformat = @ptrFromInt(@as(usize, @intCast(user_data)));
             assert(reformat.requests_done == 0);
+            assert(reformat.safe_view == null);
 
             log.debug("{}: register", .{reformat.options.replica});
 
@@ -99,6 +121,7 @@ pub fn ReplicaReformatType(
         }
 
         fn client_request(reformat: *ReplicaReformat) void {
+            assert(reformat.safe_view == null);
             assert(reformat.requests_done < constants.pipeline_prepare_queue_max);
 
             log.debug("{}: request start={}", .{
@@ -136,6 +159,7 @@ pub fn ReplicaReformatType(
             const reformat: *ReplicaReformat = @ptrFromInt(@as(usize, @intCast(user_data)));
             assert(reformat.requests_done > 0);
             assert(reformat.requests_done < constants.pipeline_prepare_queue_max);
+            assert(reformat.safe_view == null);
             assert(results.len == 0);
 
             log.debug("{}: request done={}", .{
@@ -146,17 +170,7 @@ pub fn ReplicaReformatType(
             reformat.requests_done += 1;
             if (reformat.requests_done == constants.pipeline_prepare_queue_max) {
                 // +2 since we might have sent a JV as part of +1 before we crashed.
-                reformat.options.view = reformat.client.view + 2;
-                format(
-                    Storage,
-                    reformat.allocator,
-                    reformat.storage,
-                    reformat.options,
-                ) catch |err| {
-                    reformat.result = .{ .failed = err };
-                    return;
-                };
-                reformat.result = .ok;
+                reformat.safe_view = reformat.client.view + 2;
             } else {
                 reformat.client_request();
             }


### PR DESCRIPTION
Fixes the infamous `timeouts.* -= 1` underflow.

The problem was that we run `run` from within `run_for_ns`:

    run_for_ns:
      run

`run` assumes that all timeouts created by `run_for_ns` are reaped, but this is of course not true if it is still running!

To fix, untangle the even loop structure a bit, placing the two loops side-by-side, rather than nested.