### PR TITLE
docs: Add newline before 'Creating a client'

### DIFF
--- a/src/clients/dotnet/README.md
+++ b/src/clients/dotnet/README.md
@@ -57,6 +57,7 @@ features of TigerBeetle.
 them, then post the transfer.
 * [Many Two-Phase Transfers](/src/clients/dotnet/samples/two-phase-many/): Create two accounts and start a number of pending transfers
 between them, posting and voiding alternating transfers.
+
 ## Creating a Client
 
 A client is created with a cluster ID and replica

--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -69,6 +69,7 @@ features of TigerBeetle.
 them, then post the transfer.
 * [Many Two-Phase Transfers](/src/clients/go/samples/two-phase-many/): Create two accounts and start a number of pending transfers
 between them, posting and voiding alternating transfers.
+
 ## Creating a Client
 
 A client is created with a cluster ID and replica

--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -108,6 +108,7 @@ features of TigerBeetle.
 them, then post the transfer.
 * [Many Two-Phase Transfers](/src/clients/java/samples/two-phase-many/): Create two accounts and start a number of pending transfers
 between them, posting and voiding alternating transfers.
+
 ## Creating a Client
 
 A client is created with a cluster ID and replica

--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -49,6 +49,7 @@ features of TigerBeetle.
 them, then post the transfer.
 * [Many Two-Phase Transfers](/src/clients/node/samples/two-phase-many/): Create two accounts and start a number of pending transfers
 between them, posting and voiding alternating transfers.
+
 ### Sidenote: `BigInt`
 TigerBeetle uses 64-bit integers for many fields while JavaScript's
 builtin `Number` maximum value is `2^53-1`. The `n` suffix in JavaScript

--- a/src/clients/python/README.md
+++ b/src/clients/python/README.md
@@ -53,6 +53,7 @@ features of TigerBeetle.
 them, then post the transfer.
 * [Many Two-Phase Transfers](/src/clients/python/samples/two-phase-many/): Create two accounts and start a number of pending transfers
 between them, posting and voiding alternating transfers.
+
 ## Creating a Client
 
 A client is created with a cluster ID and replica

--- a/src/clients/rust/README.md
+++ b/src/clients/rust/README.md
@@ -64,6 +64,7 @@ features of TigerBeetle.
 them, then post the transfer.
 * [Many Two-Phase Transfers](/src/clients/rust/samples/two-phase-many/): Create two accounts and start a number of pending transfers
 between them, posting and voiding alternating transfers.
+
 ## Creating a Client
 
 A client is created with a cluster ID and replica

--- a/src/scripts/client_readmes.zig
+++ b/src/scripts/client_readmes.zig
@@ -157,6 +157,7 @@ fn readme_root(ctx: *Context) !void {
                 });
             }
         }
+        ctx.print("\n", .{});
 
         if (ctx.docs.examples.len != 0) {
             ctx.paragraph(ctx.docs.examples);


### PR DESCRIPTION
`src/scripts/client_readmes.zig` did not add a newline before

```md
## Creating a Client
```

While that does not influence the rendered output, it does trigger my OCD since all the other headlines have an empty line before and after.

All relevant `README.md` files were updated via

```sh
./zig/zig build scripts -- ci --language=$LANGUAGE
```