### PR TITLE
Time Cleanup, Round 2

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -801,7 +801,7 @@ pub fn ContextType(
 
             const current_timestamp = self.client.time.monotonic();
             self.previous_request_latency =
-                current_timestamp.duration_since(self.previous_request_instant);
+                self.previous_request_instant.elapsed(current_timestamp);
 
             // The client might have a smaller message size limit.
             maybe(constants.message_body_size_max < result.batch_size_limit);
@@ -857,7 +857,7 @@ pub fn ContextType(
 
             const current_timestamp = self.client.time.monotonic();
             self.previous_request_latency =
-                current_timestamp.duration_since(self.previous_request_instant);
+                self.previous_request_instant.elapsed(current_timestamp);
 
             // Submit the next pending packet (if any) now that VSR has completed this one.
             assert(self.client.request_inflight == null);

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -228,8 +228,8 @@ pub fn ContextType(
         eviction_reason: ?vsr.Header.Eviction.Reason = null,
         thread: std.Thread,
 
-        previous_request_instant: stdx.Instant,
-        previous_request_latency: ?stdx.Duration = null,
+        request_timer: stdx.Instant,
+        request_latency: ?stdx.Duration = null,
 
         pub fn init(
             root_allocator: std.mem.Allocator,
@@ -289,7 +289,7 @@ pub fn ContextType(
                 .client = undefined,
                 .signal = undefined,
                 .thread = undefined,
-                .previous_request_instant = undefined,
+                .request_timer = undefined,
             };
             context.addresses_owned = try allocator.dupe(u8, addresses);
             errdefer allocator.free(context.addresses_owned);
@@ -375,7 +375,7 @@ pub fn ContextType(
             try context.signal.init(&context.io, Context.signal_notify_callback);
             errdefer context.signal.deinit();
 
-            context.previous_request_instant = context.client.time.monotonic();
+            context.request_timer = context.client.time.monotonic();
             context.client.register(client_register_callback, @intFromPtr(context));
 
             log.debug("{}: init: spawning thread", .{context.client_id});
@@ -713,7 +713,7 @@ pub fn ContextType(
 
             // Sending the request.
             const previous_request_latency =
-                self.previous_request_latency orelse stdx.Duration{ .ns = 0 };
+                self.request_latency orelse stdx.Duration{ .ns = 0 };
             message.header.* = .{
                 .release = self.client.release,
                 .client = self.client.id,
@@ -728,7 +728,7 @@ pub fn ContextType(
                 )),
             };
 
-            self.previous_request_instant = .{ .ns = packet_list.multi_batch_time_monotonic };
+            self.request_timer = .{ .ns = packet_list.multi_batch_time_monotonic };
 
             packet_list.phase = .sent;
             self.client.raw_request(
@@ -800,8 +800,8 @@ pub fn ContextType(
             assert(result.batch_size_limit > 0);
 
             const current_timestamp = self.client.time.monotonic();
-            self.previous_request_latency =
-                self.previous_request_instant.elapsed(current_timestamp);
+            self.request_latency =
+                self.request_timer.elapsed(current_timestamp);
 
             // The client might have a smaller message size limit.
             maybe(constants.message_body_size_max < result.batch_size_limit);
@@ -856,8 +856,8 @@ pub fn ContextType(
             packet_list.assert_phase(.sent);
 
             const current_timestamp = self.client.time.monotonic();
-            self.previous_request_latency =
-                self.previous_request_instant.elapsed(current_timestamp);
+            self.request_latency =
+                self.request_timer.elapsed(current_timestamp);
 
             // Submit the next pending packet (if any) now that VSR has completed this one.
             assert(self.client.request_inflight == null);

--- a/src/clients/c/tb_client/signal.zig
+++ b/src/clients/c/tb_client/signal.zig
@@ -195,7 +195,7 @@ test "signal" {
             assert(self.count == events_count);
 
             // Make sure at least some time has passed.
-            const elapsed = timer.monotonic().duration_since(start);
+            const elapsed = start.elapsed(timer.monotonic());
             assert(elapsed.ns >= delay);
         }
 

--- a/src/clients/c/tb_client/signal.zig
+++ b/src/clients/c/tb_client/signal.zig
@@ -174,9 +174,8 @@ test "signal" {
             try Signal.init(&self.signal, &self.io, on_signal);
             defer self.signal.deinit();
 
-            var time_os = TimeOS{};
-            const timer = time_os.time();
-            const start = timer.monotonic();
+            var time: TimeOS = .{};
+            const timer = time.monotonic();
 
             const thread = try std.Thread.spawn(.{}, Context.notify, .{&self});
 
@@ -195,7 +194,7 @@ test "signal" {
             assert(self.count == events_count);
 
             // Make sure at least some time has passed.
-            const elapsed = start.elapsed(timer.monotonic());
+            const elapsed = timer.elapsed(time.monotonic());
             assert(elapsed.ns >= delay);
         }
 

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -115,7 +115,7 @@ pub fn main() !void {
 }
 
 fn main_smoke(gpa: std.mem.Allocator) !void {
-    var time = TimeOS{};
+    var time: TimeOS = .{};
     const timer_all = time.monotonic();
     inline for (comptime std.enums.values(FuzzersEnum)) |fuzzer| {
         const events_max = switch (fuzzer) {
@@ -165,7 +165,7 @@ fn main_single(gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     const seed = cli_args.seed orelse std.crypto.random.int(u64);
     log.info("Fuzz seed = {}", .{seed});
 
-    var time = TimeOS{};
+    var time: TimeOS = .{};
     const timer = time.monotonic();
     switch (cli_args.fuzzer) {
         .smoke => unreachable,

--- a/src/fuzz_tests.zig
+++ b/src/fuzz_tests.zig
@@ -4,6 +4,7 @@ const assert = std.debug.assert;
 const stdx = @import("stdx");
 const constants = @import("./constants.zig");
 const fuzz = @import("./testing/fuzz.zig");
+const TimeOS = @import("./time.zig").TimeOS;
 
 const log = std.log.scoped(.fuzz);
 
@@ -114,7 +115,8 @@ pub fn main() !void {
 }
 
 fn main_smoke(gpa: std.mem.Allocator) !void {
-    var timer_all = try std.time.Timer.start();
+    var time = TimeOS{};
+    const timer_all = time.monotonic();
     inline for (comptime std.enums.values(FuzzersEnum)) |fuzzer| {
         const events_max = switch (fuzzer) {
             .smoke => continue,
@@ -140,20 +142,21 @@ fn main_smoke(gpa: std.mem.Allocator) !void {
             => null,
         };
 
-        var timer_single = try std.time.Timer.start();
+        const timer_single = time.monotonic();
         try @field(Fuzzers, @tagName(fuzzer)).main(gpa, .{
             .seed = 123,
             .events_max = events_max,
         });
-        const fuzz_duration = timer_single.lap();
-        if (fuzz_duration > 10 * std.time.ns_per_s) {
+        const fuzz_duration = timer_single.elapsed(time.monotonic());
+        if (fuzz_duration.ns > 10 * std.time.ns_per_s) {
             log.err("fuzzer too slow for the smoke mode: " ++ @tagName(fuzzer) ++ " {}", .{
-                std.fmt.fmtDuration(fuzz_duration),
+                std.fmt.fmtDuration(fuzz_duration.ns),
             });
         }
     }
 
-    log.info("done in {}", .{std.fmt.fmtDuration(timer_all.lap())});
+    const elapsed = timer_all.elapsed(time.monotonic());
+    log.info("done in {}", .{std.fmt.fmtDuration(elapsed.ns)});
 }
 
 fn main_single(gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
@@ -162,7 +165,8 @@ fn main_single(gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     const seed = cli_args.seed orelse std.crypto.random.int(u64);
     log.info("Fuzz seed = {}", .{seed});
 
-    var timer = try std.time.Timer.start();
+    var time = TimeOS{};
+    const timer = time.monotonic();
     switch (cli_args.fuzzer) {
         .smoke => unreachable,
         .canary => {
@@ -175,5 +179,6 @@ fn main_single(gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
             .events_max = cli_args.events_max,
         }),
     }
-    log.info("done in {}", .{std.fmt.fmtDuration(timer.lap())});
+    const elapsed = timer.elapsed(time.monotonic());
+    log.info("done in {}", .{std.fmt.fmtDuration(elapsed.ns)});
 }

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -20,7 +20,7 @@ pub const IO = struct {
 
     kq: fd_t,
     event_id: Event = 0,
-    time_os: TimeOS = .{},
+    time: TimeOS = .{},
     io_inflight: usize = 0,
     timeouts: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_timeouts" }),
     completed: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_completed" }),
@@ -63,8 +63,11 @@ pub const IO = struct {
         }
         defer self.stats.trace();
 
-        var timer = try std.time.Timer.start();
-        defer self.stats.window.time_run_for_ns.ns += timer.read();
+        const timer = self.time.monotonic();
+        defer {
+            const elapsed = timer.elapsed(self.time.monotonic());
+            self.stats.window.time_run_for_ns.ns += elapsed.ns;
+        }
 
         var timed_out = false;
         var completion: Completion = undefined;
@@ -146,11 +149,12 @@ pub const IO = struct {
         var completed = self.completed;
         self.completed.reset();
 
-        var timer = try std.time.Timer.start();
+        const timer = self.time.monotonic();
         while (completed.pop()) |completion| {
             (completion.callback)(self, completion);
         }
-        self.stats.window.time_callbacks.ns += timer.read();
+        const elapsed = timer.elapsed(self.time.monotonic());
+        self.stats.window.time_callbacks.ns += elapsed.ns;
     }
 
     fn flush_io(self: *IO, events: []posix.Kevent) usize {
@@ -185,7 +189,7 @@ pub const IO = struct {
         while (timeouts_iterator.next()) |completion| {
 
             // NOTE: We could cache `now` above the loop but monotonic() should be cheap to call.
-            const now = self.time_os.monotonic().ns;
+            const now = self.time.monotonic().ns;
             const expires = completion.operation.timeout.expires;
 
             // NOTE: remove() could be O(1) here with a doubly-linked-list
@@ -765,7 +769,7 @@ pub const IO = struct {
             completion,
             .timeout,
             .{
-                .expires = self.time_os.monotonic().ns + nanoseconds,
+                .expires = self.time.monotonic().ns + nanoseconds,
             },
             struct {
                 fn do_operation(_: anytype) TimeoutError!void {

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -64,10 +64,8 @@ pub const IO = struct {
         defer self.stats.trace();
 
         const timer = self.time.monotonic();
-        defer {
-            const elapsed = timer.elapsed(self.time.monotonic());
-            self.stats.window.time_run_for_ns.ns += elapsed.ns;
-        }
+        defer self.stats.window.time_run_for_ns.ns +=
+            timer.elapsed(self.time.monotonic()).ns;
 
         var timed_out = false;
         var completion: Completion = undefined;

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -128,7 +128,7 @@ pub const IO = struct {
 
         const timer = self.time.monotonic();
         defer self.stats.window.time_run_for_ns.ns +=
-            self.time.monotonic().duration_since(timer).ns;
+            timer.elapsed(self.time.monotonic()).ns;
 
         var now = self.time.monotonic();
         const deadline = now.add(.{ .ns = nanoseconds });
@@ -163,7 +163,7 @@ pub const IO = struct {
             // Doesn't account for flush_completions below; which indicates a bad assumption either
             // on our sizing of the loop, or a bug in the kernel.
             defer self.stats.window.time_kernel.ns +=
-                self.time.monotonic().duration_since(timer).ns;
+                timer.elapsed(self.time.monotonic()).ns;
 
             const submitted = submit_and_wait_timeout(
                 &self.ring,
@@ -227,7 +227,7 @@ pub const IO = struct {
 
         const timer = self.time.monotonic();
         defer self.stats.window.time_callbacks.ns +=
-            self.time.monotonic().duration_since(timer).ns;
+            timer.elapsed(self.time.monotonic()).ns;
 
         if (completion.operation == .next_tick) {
             // next_tick completions are never submitted to the kernel,

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -360,9 +360,8 @@ test "event" {
             self.event = try self.io.open_event();
             defer self.io.close_event(self.event);
 
-            var time_os: TimeOS = .{};
-            const timer = time_os.time();
-            const start = timer.monotonic();
+            var time: TimeOS = .{};
+            const timer = time.monotonic();
 
             // Listen to the event and spawn a thread that triggers the completion after some time.
             self.io.event_listen(self.event, &self.event_completion, on_event);
@@ -376,7 +375,7 @@ test "event" {
             assert(self.count == events_count);
 
             // Make sure at least some time has passed.
-            const elapsed = start.elapsed(timer.monotonic());
+            const elapsed = timer.elapsed(time.monotonic());
             assert(elapsed.ns >= delay);
         }
 

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -376,7 +376,7 @@ test "event" {
             assert(self.count == events_count);
 
             // Make sure at least some time has passed.
-            const elapsed = timer.monotonic().duration_since(start);
+            const elapsed = start.elapsed(timer.monotonic());
             assert(elapsed.ns >= delay);
         }
 

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -19,7 +19,7 @@ pub const IO = struct {
     pub const NextTickSource = common.NextTickSource;
 
     iocp: os.windows.HANDLE,
-    time_os: TimeOS = .{},
+    time: TimeOS = .{},
     io_pending: usize = 0,
     timeouts: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_timeouts" }),
     completed: QueueType(Completion) = QueueType(Completion).init(.{ .name = "io_completed" }),
@@ -67,8 +67,11 @@ pub const IO = struct {
 
         defer self.stats.trace();
 
-        var timer = try std.time.Timer.start();
-        defer self.stats.window.time_run_for_ns.ns += timer.read();
+        const timer = self.time.monotonic();
+        defer {
+            const elapsed = timer.elapsed(self.time.monotonic());
+            self.stats.window.time_run_for_ns.ns += elapsed.ns;
+        }
 
         const Callback = struct {
             fn on_timeout(
@@ -156,14 +159,15 @@ pub const IO = struct {
         var completed = self.completed;
         self.completed.reset();
 
-        var timer = try std.time.Timer.start();
+        const timer = self.time.monotonic();
         while (completed.pop()) |completion| {
             (completion.callback)(Completion.Context{
                 .io = self,
                 .completion = completion,
             });
         }
-        self.stats.window.time_callbacks.ns += timer.read();
+        const elapsed = timer.elapsed(self.time.monotonic());
+        self.stats.window.time_callbacks.ns += elapsed.ns;
     }
 
     fn flush_timeouts(self: *IO) ?u64 {
@@ -174,7 +178,7 @@ pub const IO = struct {
         var timeouts_iterator = self.timeouts.iterate();
         while (timeouts_iterator.next()) |completion| {
             // Lazily get the current time.
-            const now = current_time orelse self.time_os.monotonic().ns;
+            const now = current_time orelse self.time.monotonic().ns;
             current_time = now;
 
             // Move the completion to completed if it expired.
@@ -1051,7 +1055,7 @@ pub const IO = struct {
             callback,
             completion,
             .timeout,
-            .{ .deadline = self.time_os.monotonic().ns + nanoseconds },
+            .{ .deadline = self.time.monotonic().ns + nanoseconds },
             struct {
                 fn do_operation(ctx: Completion.Context, op: anytype) TimeoutError!void {
                     _ = ctx;

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -68,10 +68,8 @@ pub const IO = struct {
         defer self.stats.trace();
 
         const timer = self.time.monotonic();
-        defer {
-            const elapsed = timer.elapsed(self.time.monotonic());
-            self.stats.window.time_run_for_ns.ns += elapsed.ns;
-        }
+        defer self.stats.window.time_run_for_ns.ns +=
+            timer.elapsed(self.time.monotonic()).ns;
 
         const Callback = struct {
             fn on_timeout(

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -592,13 +592,13 @@ fn run_timeout_test(
     );
     defer _ = cdc_job.kill() catch undefined;
 
-    const started = time.monotonic();
+    const timer = time.monotonic();
 
     // Kills the TigerBeetle cluster and waits for the CDC job to time out.
     tmp_beetle.deinit(gpa);
     const result = try cdc_job.wait();
 
-    const elapsed = started.elapsed(time.monotonic());
+    const elapsed = timer.elapsed(time.monotonic());
 
     try testing.expectEqual(@as(u8, 1), result.Exited);
     try testing.expect(elapsed.to_ms() > 1000);

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -598,7 +598,7 @@ fn run_timeout_test(
     tmp_beetle.deinit(gpa);
     const result = try cdc_job.wait();
 
-    const elapsed = time.monotonic().duration_since(started);
+    const elapsed = started.elapsed(time.monotonic());
 
     try testing.expectEqual(@as(u8, 1), result.Exited);
     try testing.expect(elapsed.to_ms() > 1000);

--- a/src/stdx/time_units.zig
+++ b/src/stdx/time_units.zig
@@ -15,7 +15,7 @@ pub const Instant = struct {
         return .{ .ns = now.ns + duration.ns };
     }
 
-    pub fn duration_since(now: Instant, earlier: Instant) Duration {
+    pub fn elapsed(earlier: Instant, now: Instant) Duration {
         assert(now.ns >= earlier.ns);
         const elapsed_ns = now.ns - earlier.ns;
         return .{ .ns = elapsed_ns };
@@ -160,10 +160,10 @@ pub const Duration = struct {
 test "Instant/Duration" {
     const instant_1: Instant = .{ .ns = 100 * std.time.ns_per_day };
     const instant_2: Instant = .{ .ns = 100 * std.time.ns_per_day + std.time.ns_per_s };
-    assert(instant_1.duration_since(instant_1).ns == 0);
-    assert(instant_2.duration_since(instant_1).ns == std.time.ns_per_s);
+    assert(instant_1.elapsed(instant_1).ns == 0);
+    assert(instant_1.elapsed(instant_2).ns == std.time.ns_per_s);
 
-    const duration = instant_2.duration_since(instant_1);
+    const duration = instant_1.elapsed(instant_2);
     assert(duration.ns == 1_000_000_000);
     assert(duration.to_us() == 1_000_000);
     assert(duration.to_ms() == 1_000);

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -220,7 +220,7 @@ pub fn StorageType(comptime IO: type) type {
 
                 self.tracer.timing(
                     .{ .storage_read = .{ .zone = read.zone } },
-                    self.tracer.time.monotonic().duration_since(read.start.?),
+                    read.start.?.elapsed(self.tracer.time.monotonic()),
                 );
 
                 read.callback(read);
@@ -431,7 +431,7 @@ pub fn StorageType(comptime IO: type) type {
             if (write.buffer.len == 0) {
                 self.tracer.timing(
                     .{ .storage_write = .{ .zone = write.zone } },
-                    self.tracer.time.monotonic().duration_since(write.start.?),
+                    write.start.?.elapsed(self.tracer.time.monotonic()),
                 );
 
                 write.callback(write);

--- a/src/testing/bench.zig
+++ b/src/testing/bench.zig
@@ -66,7 +66,7 @@ const mode: enum { smoke, benchmark } =
 
 seed: u64,
 time: TimeOS = .{},
-instant_start: ?Instant = null,
+timer: ?Instant = null,
 
 const Bench = @This();
 
@@ -78,7 +78,7 @@ pub fn init() Bench {
 }
 
 pub fn deinit(bench: *Bench) void {
-    assert(bench.instant_start == null);
+    assert(bench.timer == null);
     bench.* = undefined;
 }
 
@@ -112,19 +112,19 @@ fn parameter_fallible(
 }
 
 pub fn start(bench: *Bench) void {
-    assert(bench.instant_start == null);
-    defer assert(bench.instant_start != null);
+    assert(bench.timer == null);
+    defer assert(bench.timer != null);
 
-    bench.instant_start = bench.time.time().monotonic();
+    bench.timer = bench.time.time().monotonic();
 }
 
 pub fn stop(bench: *Bench) Duration {
-    assert(bench.instant_start != null);
-    defer assert(bench.instant_start == null);
+    assert(bench.timer != null);
+    defer assert(bench.timer == null);
 
     const instant_stop = bench.time.time().monotonic();
-    const elapsed = instant_stop.duration_since(bench.instant_start.?);
-    bench.instant_start = null;
+    const elapsed = bench.timer.?.elapsed(instant_stop);
+    bench.timer = null;
     return elapsed;
 }
 

--- a/src/tigerbeetle/inspect_integrity.zig
+++ b/src/tigerbeetle/inspect_integrity.zig
@@ -399,8 +399,8 @@ fn check_grid(integrity: *Integrity, seed: u64) !u64 {
     });
     defer parent_progress_node.end();
 
-    var timer = try std.time.Timer.start();
-    timer.reset();
+    var time = vsr.time.TimeOS{};
+    const timer = time.monotonic();
 
     while (true) {
         for (0..integrity.grid_scrubber.reads.available() + 1) |_| {
@@ -435,7 +435,7 @@ fn check_grid(integrity: *Integrity, seed: u64) !u64 {
 
         try integrity.io.run_for_ns(constants.tick_ms * std.time.ns_per_ms);
     }
-    const grid_duration_ms = stdx.div_ceil(timer.read(), std.time.ns_per_ms);
+    const grid_duration = timer.elapsed(time.monotonic());
 
     assert(integrity.grid_scrubber.tour == .done and
         integrity.grid_scrubber.reads.executing() == 0);
@@ -464,12 +464,12 @@ fn check_grid(integrity: *Integrity, seed: u64) !u64 {
 
     const throughput = @divFloor(@divFloor(
         blocks_expected_count * constants.block_size,
-        stdx.div_ceil(grid_duration_ms, std.time.ms_per_s),
+        stdx.div_ceil(grid_duration.to_ms(), std.time.ms_per_s),
     ), 1024 * 1024);
 
     log.info("successfully checked {} grid blocks in {}ms. ({}MiB/s)", .{
         blocks_expected_count,
-        grid_duration_ms,
+        grid_duration.to_ms(),
         throughput,
     });
 

--- a/src/tigerbeetle/inspect_integrity.zig
+++ b/src/tigerbeetle/inspect_integrity.zig
@@ -399,7 +399,7 @@ fn check_grid(integrity: *Integrity, seed: u64) !u64 {
     });
     defer parent_progress_node.end();
 
-    var time = vsr.time.TimeOS{};
+    var time: vsr.time.TimeOS = .{};
     const timer = time.monotonic();
 
     while (true) {

--- a/src/time.zig
+++ b/src/time.zig
@@ -180,8 +180,8 @@ test "Time monotonic smoke" {
     const time = time_os.time();
     const instant_1 = time.monotonic();
     const instant_2 = time.monotonic();
-    assert(instant_1.duration_since(instant_1).ns == 0);
-    assert(instant_2.duration_since(instant_1).ns >= 0);
+    assert(instant_1.elapsed(instant_1).ns == 0);
+    assert(instant_1.elapsed(instant_2).ns >= 0);
 }
 
 /// Equivalent to `std.time.Timer`,
@@ -201,7 +201,7 @@ pub const Timer = struct {
     pub fn read(self: *Timer) stdx.Duration {
         const current = self.time.monotonic();
         assert(current.ns >= self.started.ns);
-        return current.duration_since(self.started);
+        return self.started.elapsed(current);
     }
 
     /// Resets the timer.

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -288,7 +288,7 @@ pub fn start(tracer: *Tracer, event: Event) void {
     }
 
     const writer = tracer.options.writer orelse return;
-    const time_elapsed = time_now.duration_since(tracer.time_start);
+    const time_elapsed = tracer.time_start.elapsed(time_now);
 
     var buffer_stream = std.io.fixedBufferStream(tracer.buffer);
 
@@ -335,7 +335,7 @@ pub fn stop(tracer: *Tracer, event: Event) void {
 
     const event_start = tracer.events_started[stack].?;
     const event_end = tracer.time.monotonic();
-    const event_duration = event_end.duration_since(event_start);
+    const event_duration = event_start.elapsed(event_end);
 
     assert(tracer.events_started[stack] != null);
     tracer.events_started[stack] = null;
@@ -361,7 +361,7 @@ pub fn stop(tracer: *Tracer, event: Event) void {
         });
     }
 
-    tracer.write_stop(stack, event_end.duration_since(tracer.time_start));
+    tracer.write_stop(stack, tracer.time_start.elapsed(event_end));
 }
 
 pub fn cancel(tracer: *Tracer, event_tag: Event.Tag) void {
@@ -374,7 +374,7 @@ pub fn cancel(tracer: *Tracer, event_tag: Event.Tag) void {
                 log.debug("{}: {s}: cancel", .{ tracer.process_id, @tagName(event_tag) });
             }
 
-            const event_duration = event_end.duration_since(tracer.time_start);
+            const event_duration = tracer.time_start.elapsed(event_end);
 
             tracer.events_started[stack] = null;
             tracer.write_stop(@intCast(stack), event_duration);

--- a/src/vsr/fault_detector.zig
+++ b/src/vsr/fault_detector.zig
@@ -57,7 +57,7 @@ pub fn init(options: struct {
 pub fn signal(detector: *FaultDetector, now: Instant) void {
     const past = detector.signal_last;
     assert(past.ns <= now.ns);
-    const interval = now.duration_since(past)
+    const interval = past.elapsed(now)
         // Clamp first, then ewma_add, to avoid overflows.
         .clamp(detector.interval_min, detector.interval_max);
 
@@ -86,7 +86,7 @@ pub fn signal(detector: *FaultDetector, now: Instant) void {
 pub fn tardy(detector: *FaultDetector, now: Instant) enum { green, yellow, red } {
     const past = detector.signal_last;
     assert(past.ns <= now.ns);
-    const interval = now.duration_since(past);
+    const interval = past.elapsed(now);
 
     if (interval.ns *| 2 <= detector.interval_ewma.ns * 3) { // interval <= 1.5 * interval_ewma
         return .green;
@@ -187,23 +187,23 @@ test "FaultDetector: smoothing" {
     const commit_interval: Duration = .ms(500);
     const request_interval: Duration = .ms(100);
 
-    var commit_last = now;
-    var request_last = now;
+    var commit_timer = now;
+    var request_timer = now;
 
     for (0..1_000) |_| {
         now = now.add(.ms(10)); // Advance by one tick.
 
         // Primary broadcasts commit message every 500ms.
-        if (now.duration_since(commit_last).ns > commit_interval.ns) {
-            commit_last = now;
+        if (commit_timer.elapsed(now).ns > commit_interval.ns) {
+            commit_timer = now;
             primary.signal(now);
             backup.signal(now.add(backup_delay));
         }
         assert(primary.tardy(now) == .green);
 
         // Primary converts a request into prepare every 100ms.
-        if (now.duration_since(request_last).ns > request_interval.ns) {
-            request_last = now;
+        if (request_timer.elapsed(now).ns > request_interval.ns) {
+            request_timer = now;
             primary.signal(now);
             backup.signal(now.add(backup_delay));
         }
@@ -215,8 +215,8 @@ test "FaultDetector: smoothing" {
     for (0..1_000) |_| {
         now = now.add(.ms(10)); // Advance by one tick.
 
-        if (now.duration_since(commit_last).ns > commit_interval.ns) {
-            commit_last = now;
+        if (commit_timer.elapsed(now).ns > commit_interval.ns) {
+            commit_timer = now;
             primary.signal(now);
             backup.signal(now.add(backup_delay));
         }
@@ -262,7 +262,7 @@ test "FaultDetector: smoothing" {
                 // primary needs to grow proportionally more, and that feels like too much of a lag.
                 // Instead, we let go of the constraint of keeping the heartbeat steady, and skip
                 // the next normal beat whenever we inject one.
-                commit_last = now;
+                commit_timer = now;
 
                 primary.signal(now);
                 backup.signal(now.add(backup_delay));

--- a/src/vsr/fault_detector.zig
+++ b/src/vsr/fault_detector.zig
@@ -57,11 +57,11 @@ pub fn init(options: struct {
 pub fn signal(detector: *FaultDetector, now: Instant) void {
     const past = detector.signal_last;
     assert(past.ns <= now.ns);
-    const interval = past.elapsed(now)
+    const elapsed = past.elapsed(now)
         // Clamp first, then ewma_add, to avoid overflows.
         .clamp(detector.interval_min, detector.interval_max);
 
-    detector.interval_ewma = ewma_add_duration(detector.interval_ewma, interval);
+    detector.interval_ewma = ewma_add_duration(detector.interval_ewma, elapsed);
     detector.signal_last = now;
 }
 
@@ -86,16 +86,16 @@ pub fn signal(detector: *FaultDetector, now: Instant) void {
 pub fn tardy(detector: *FaultDetector, now: Instant) enum { green, yellow, red } {
     const past = detector.signal_last;
     assert(past.ns <= now.ns);
-    const interval = past.elapsed(now);
+    const elapsed = past.elapsed(now);
 
-    if (interval.ns *| 2 <= detector.interval_ewma.ns * 3) { // interval <= 1.5 * interval_ewma
+    if (elapsed.ns *| 2 <= detector.interval_ewma.ns * 3) { // interval <= 1.5 * interval_ewma
         return .green;
     }
-    assert(interval.ns >= detector.interval_ewma.ns);
-    if (interval.ns <= detector.interval_ewma.ns * 3) {
+    assert(elapsed.ns >= detector.interval_ewma.ns);
+    if (elapsed.ns <= detector.interval_ewma.ns * 3) {
         return .yellow;
     }
-    assert(interval.ns > detector.interval_ewma.ns);
+    assert(elapsed.ns > detector.interval_ewma.ns);
     return .red;
 }
 

--- a/src/vsr/repair_budget.zig
+++ b/src/vsr/repair_budget.zig
@@ -186,7 +186,7 @@ pub const RepairBudgetJournal = struct {
                 // to a new checkpoint), in which case we request a unique op from each replica.
                 budget.replicas_repair_latency[replica_index] = ewma_add_duration(
                     budget.replicas_repair_latency[replica_index],
-                    now.duration_since(requested_prepare.value),
+                    requested_prepare.value.elapsed(now),
                 );
             }
         }
@@ -219,7 +219,7 @@ pub const RepairBudgetJournal = struct {
 
             while (requested_prepares_index < requested_prepares.entries.len) {
                 const requested_at = requested_prepares.values()[requested_prepares_index];
-                const duration_since_requested_at = now.duration_since(requested_at);
+                const duration_since_requested_at = requested_at.elapsed(now);
                 const duration_expiry_ns = @min(
                     budget.repair_latency_multiple_expiry *
                         budget.replicas_repair_latency[replica_index].ns,
@@ -385,7 +385,7 @@ pub const RepairBudgetGrid = struct {
         for (budget.replicas_requested_blocks, 0..) |requested_blocks, index| {
             if (requested_blocks.get(block_identifier)) |requested_at| {
                 assert(index != budget.replica_index);
-                const duration_since_requested = now.duration_since(requested_at);
+                const duration_since_requested = requested_at.elapsed(now);
                 if (duration_since_requested_min == null or
                     duration_since_requested.ns < duration_since_requested_min.?.ns)
                 {
@@ -450,7 +450,7 @@ pub const RepairBudgetGrid = struct {
 
             while (requested_blocks_index < requested_blocks.entries.len) {
                 const requested_at = requested_blocks.values()[requested_blocks_index];
-                const duration_since_requested_at = now.duration_since(requested_at);
+                const duration_since_requested_at = requested_at.elapsed(now);
 
                 if (duration_since_requested_at.ns > duration_expiry.ns) {
                     requested_blocks.swapRemoveAt(requested_blocks_index);

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5223,9 +5223,8 @@ pub fn ReplicaType(
                 .ns = @as(u64, @intCast(self.clock.realtime())) -|
                     self.commit_prepare.?.header.timestamp,
             };
-            const commit_completion_time_local = self.commit_started.?.elapsed(
-                self.clock.monotonic()
-            );
+            const commit_completion_time_local =
+                self.commit_started.?.elapsed(self.clock.monotonic());
 
             // Only time operations when:
             // * Running with the real state machine - as otherwise there's a circular dependency,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1558,7 +1558,7 @@ pub fn ReplicaType(
                         .{
                             self.replica,
                             self.commit_fault.interval_ewma,
-                            now.duration_since(self.commit_fault.signal_last),
+                            self.commit_fault.signal_last.elapsed(now),
                         },
                     );
                 }
@@ -1576,7 +1576,7 @@ pub fn ReplicaType(
                         .{
                             self.replica,
                             self.commit_fault.interval_ewma,
-                            now.duration_since(self.commit_fault.signal_last),
+                            self.commit_fault.signal_last.elapsed(now),
                         },
                     );
                     self.send_exit_view();
@@ -5223,8 +5223,7 @@ pub fn ReplicaType(
                 .ns = @as(u64, @intCast(self.clock.realtime())) -|
                     self.commit_prepare.?.header.timestamp,
             };
-            const commit_completion_time_local = self.clock.monotonic()
-                .duration_since(self.commit_started.?);
+            const commit_completion_time_local = self.commit_started.?.elapsed(self.clock.monotonic());
 
             // Only time operations when:
             // * Running with the real state machine - as otherwise there's a circular dependency,

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -5223,7 +5223,9 @@ pub fn ReplicaType(
                 .ns = @as(u64, @intCast(self.clock.realtime())) -|
                     self.commit_prepare.?.header.timestamp,
             };
-            const commit_completion_time_local = self.commit_started.?.elapsed(self.clock.monotonic());
+            const commit_completion_time_local = self.commit_started.?.elapsed(
+                self.clock.monotonic()
+            );
 
             // Only time operations when:
             // * Running with the real state machine - as otherwise there's a circular dependency,


### PR DESCRIPTION
This PR applies cleans up several minor things around time:
- Apply Alex's suggested rename of `Instant.duration_since(present, past)` to `Instant.elapsed(past, present)`
- Use `timer` instead of `some_past_instant` for variable naming where it makes sense
- Removes more instances of `std.time.Timer`, which will be gone in its current form in zig 0.16

The std Timer is still used in some benchmarks, `shell.zig` and `scripts/` for which I want to introduce a separate replacement inside `stdx` in a future PR together with performance counters.
