### PR TITLE
CI: Fix io test flake

### DIFF
--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -280,7 +280,7 @@ test "accept/connect/send/receive" {
 
 test "timeout" {
     const ms = 20;
-    const margin = 100;
+    const margin_ms = 2;
     const count = 10;
 
     try struct {
@@ -316,11 +316,9 @@ test "timeout" {
             try self.io.run();
             try testing.expectEqual(@as(u32, count), self.count);
 
-            try testing.expectApproxEqAbs(
-                @as(f64, ms),
-                @as(f64, @floatFromInt((self.stop_time - start_time) / std.time.ns_per_ms)),
-                margin,
-            );
+            // Allow the timeout to be much too long since cloud CI can have large delays.
+            const elapsed_ms = @divFloor((self.stop_time - start_time), std.time.ns_per_ms);
+            try testing.expect(elapsed_ms > ms - margin_ms);
         }
 
         fn timeout_callback(


### PR DESCRIPTION
```
error: 'io.test.test.timeout' failed: actual 2.7e2, not within absolute tolerance 1e2 of expected 2e1
/Users/runner/work/tigerbeetle/tigerbeetle/zig/lib/std/testing.zig:276:13: 0x10f790823 in expectApproxEqAbsInner__anon_119197 (test-unit)
            return error.TestExpectedApproxEqAbs;
```