### PR TITLE
VSR: Add assert to CheckpointTrailer.open

### DIFF
--- a/src/vsr/checkpoint_trailer.zig
+++ b/src/vsr/checkpoint_trailer.zig
@@ -231,6 +231,7 @@ pub fn CheckpointTrailerType(comptime Storage: type) type {
             defer assert(trailer.callback == .open);
 
             assert(reference.trailer_size % trailer.trailer_type.item_size() == 0);
+            assert(block_count_for_trailer_size(reference.trailer_size) <= trailer.blocks.len);
             assert(trailer.size == 0);
             assert(trailer.size_transferred == 0);
             assert(trailer.block_index == 0);


### PR DESCRIPTION
The out-of-bounds write described in https://github.com/Swival/security-audits/blob/main/tigerbeetle/013-oversized-trailer-reference-writes-past-block-arrays.md does not actually exist:

- It requires `ReleaseFast` (in order to disable bounds checks). We always build in `ReleaseSafe` or `Debug`.
- Additionally, it depends on either:
  - "attacker with local-filesystem access who can craft a data file", which is outside of our fault model.
  - "disk corruption that happens to produce a valid superblock quorum", which is also outside our fault model, since it is so ludicrously improbable.

That said, the recommended fix is a nice assert, so adding it anyway!