### PR TITLE
stdx: Add to_case helper

### DIFF
--- a/src/cdc/amqp/types.zig
+++ b/src/cdc/amqp/types.zig
@@ -189,12 +189,13 @@ pub const QueueDeclareArguments = struct {
                         if (@field(arguments, field.name)) |value| {
                             const FieldType = @TypeOf(value);
                             // Keys are follow the pattern "x-max-length":
-                            const key = comptime "x-" ++ vsr.stdx.to_case(field.name, .kebab);
+                            const key = comptime "x-" ++
+                                vsr.stdx.to_case(field.name, .@"kebab-case");
                             switch (FieldType) {
                                 []const u8 => encoder.put(key, .{ .string = value }),
                                 QueueOverflow => encoder.put(key, .{ .string = switch (value) {
                                     inline else => |tag| comptime "" ++
-                                        vsr.stdx.to_case(@tagName(tag), .kebab),
+                                        vsr.stdx.to_case(@tagName(tag), .@"kebab-case"),
                                 } }),
                                 bool => encoder.put(key, .{ .boolean = value }),
                                 u32 => encoder.put(key, .{ .uint32 = value }),

--- a/src/cdc/amqp/types.zig
+++ b/src/cdc/amqp/types.zig
@@ -189,24 +189,18 @@ pub const QueueDeclareArguments = struct {
                         if (@field(arguments, field.name)) |value| {
                             const FieldType = @TypeOf(value);
                             // Keys are follow the pattern "x-max-length":
-                            const key = comptime "x-" ++ kebab_case(field.name);
+                            const key = comptime "x-" ++ vsr.stdx.to_case(field.name, .kebab);
                             switch (FieldType) {
                                 []const u8 => encoder.put(key, .{ .string = value }),
                                 QueueOverflow => encoder.put(key, .{ .string = switch (value) {
-                                    inline else => |tag| comptime "" ++ kebab_case(@tagName(tag)),
+                                    inline else => |tag| comptime "" ++
+                                        vsr.stdx.to_case(@tagName(tag), .kebab),
                                 } }),
                                 bool => encoder.put(key, .{ .boolean = value }),
                                 u32 => encoder.put(key, .{ .uint32 = value }),
                                 else => comptime unreachable,
                             }
                         }
-                    }
-                }
-                fn kebab_case(comptime key: []const u8) []const u8 {
-                    comptime {
-                        var buffer: [key.len]u8 = @as(*const [key.len]u8, @ptrCast(key)).*;
-                        std.mem.replaceScalar(u8, &buffer, '_', '-');
-                        return &buffer;
                     }
                 }
             }.write,

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -102,7 +102,7 @@ fn emit_enum(
         }
 
         if (!skip) {
-            const field_name = stdx.to_case(field.name, .upper);
+            const field_name = stdx.to_case(field.name, .UPPER_CASE);
             if (@typeInfo(Type) == .@"enum") {
                 const int_value = @intFromEnum(@field(Type, field.name));
                 try buffer.writer().print("    {s}_{s} = {s},\n", .{

--- a/src/clients/c/tb_client_header.zig
+++ b/src/clients/c/tb_client_header.zig
@@ -3,6 +3,7 @@ const assert = std.debug.assert;
 
 const vsr = @import("vsr");
 const exports = vsr.tb_client.exports;
+const stdx = vsr.stdx;
 
 const type_mappings = .{
     .{ exports.tb_account_flags, "TB_ACCOUNT_FLAGS" },
@@ -81,15 +82,6 @@ fn resolve_c_type(comptime Type: type) []const u8 {
     }
 }
 
-fn to_uppercase(comptime input: []const u8) [input.len]u8 {
-    comptime var output: [input.len]u8 = undefined;
-    inline for (&output, 0..) |*char, i| {
-        char.* = input[i];
-        char.* -= 32 * @as(u8, @intFromBool(char.* >= 'a' and char.* <= 'z'));
-    }
-    return output;
-}
-
 fn emit_enum(
     buffer: *std.ArrayList(u8),
     comptime Type: type,
@@ -110,12 +102,12 @@ fn emit_enum(
         }
 
         if (!skip) {
-            const field_name = to_uppercase(field.name);
+            const field_name = stdx.to_case(field.name, .upper);
             if (@typeInfo(Type) == .@"enum") {
                 const int_value = @intFromEnum(@field(Type, field.name));
                 try buffer.writer().print("    {s}_{s} = {s},\n", .{
                     c_name[0..suffix_pos],
-                    @as([]const u8, &field_name),
+                    field_name,
                     if (int_value == std.math.maxInt(@TypeOf(int_value)))
                         std.fmt.comptimePrint("0x{X}", .{int_value})
                     else
@@ -125,7 +117,7 @@ fn emit_enum(
                 // Packed structs.
                 try buffer.writer().print("    {s}_{s} = 1 << {},\n", .{
                     c_name[0..suffix_pos],
-                    @as([]const u8, &field_name),
+                    field_name,
                     i,
                 });
             }

--- a/src/clients/c/tb_client_header_test.zig
+++ b/src/clients/c/tb_client_header_test.zig
@@ -63,7 +63,7 @@ test "valid tb_client.h" {
                 // Compare the enum int values in C to the enum int values in Zig.
                 for (std.meta.fields(ty)) |field| {
                     if (std.mem.startsWith(u8, field.name, "deprecated_")) continue;
-                    const c_enum_field = stdx.to_case(to_snakecase(field.name), .upper);
+                    const c_enum_field = stdx.to_case(to_snakecase(field.name), .UPPER_CASE);
                     const c_value = @field(c, c_enum_prefix ++ c_enum_field);
 
                     const zig_value = @intFromEnum(@field(ty, field.name));
@@ -80,7 +80,8 @@ test "valid tb_client.h" {
                     for (std.meta.fields(ty)) |field| {
                         if (!std.mem.eql(u8, field.name, "padding")) {
                             // Get the bit value in the C enum.
-                            const c_enum_field = stdx.to_case(to_snakecase(field.name), .upper);
+                            const c_enum_field =
+                                stdx.to_case(to_snakecase(field.name), .UPPER_CASE);
                             const c_value = @field(c, c_enum_prefix ++ c_enum_field);
 
                             // Compare the bit value to the packed struct's field.

--- a/src/clients/c/tb_client_header_test.zig
+++ b/src/clients/c/tb_client_header_test.zig
@@ -3,15 +3,7 @@ const assert = std.debug.assert;
 
 const exports = @import("tb_client.zig").exports;
 const c = @cImport(@cInclude("tb_client.h"));
-
-fn to_uppercase(comptime input: []const u8) []const u8 {
-    comptime var uppercase: [input.len]u8 = undefined;
-    inline for (input, 0..) |char, i| {
-        const is_lowercase = (char >= 'a') and (char <= 'z');
-        uppercase[i] = char - (@as(u8, @intFromBool(is_lowercase)) * 32);
-    }
-    return &uppercase;
-}
+const stdx = @import("../../stdx/stdx.zig");
 
 fn to_snakecase(comptime input: []const u8) []const u8 {
     comptime var output: []const u8 = &.{};
@@ -71,7 +63,7 @@ test "valid tb_client.h" {
                 // Compare the enum int values in C to the enum int values in Zig.
                 for (std.meta.fields(ty)) |field| {
                     if (std.mem.startsWith(u8, field.name, "deprecated_")) continue;
-                    const c_enum_field = to_uppercase(to_snakecase(field.name));
+                    const c_enum_field = stdx.to_case(to_snakecase(field.name), .upper);
                     const c_value = @field(c, c_enum_prefix ++ c_enum_field);
 
                     const zig_value = @intFromEnum(@field(ty, field.name));
@@ -88,7 +80,7 @@ test "valid tb_client.h" {
                     for (std.meta.fields(ty)) |field| {
                         if (!std.mem.eql(u8, field.name, "padding")) {
                             // Get the bit value in the C enum.
-                            const c_enum_field = to_uppercase(to_snakecase(field.name));
+                            const c_enum_field = stdx.to_case(to_snakecase(field.name), .upper);
                             const c_value = @field(c, c_enum_prefix ++ c_enum_field);
 
                             // Compare the bit value to the packed struct's field.

--- a/src/clients/c/tb_client_header_test.zig
+++ b/src/clients/c/tb_client_header_test.zig
@@ -3,7 +3,7 @@ const assert = std.debug.assert;
 
 const exports = @import("tb_client.zig").exports;
 const c = @cImport(@cInclude("tb_client.h"));
-const stdx = @import("../../stdx/stdx.zig");
+const stdx = @import("stdx");
 
 fn to_snakecase(comptime input: []const u8) []const u8 {
     comptime var output: []const u8 = &.{};

--- a/src/clients/dotnet/dotnet_bindings.zig
+++ b/src/clients/dotnet/dotnet_bindings.zig
@@ -230,13 +230,13 @@ fn emit_enum(
         try emit_docs(buffer, mapping, field.name);
         if (is_packed_struct) {
             try buffer.writer().print("    {s} = 1 << {},\n\n", .{
-                stdx.to_case(field.name, .pascal),
+                stdx.to_case(field.name, .PascalCase),
                 i,
             });
         } else {
             const int_value = @intFromEnum(@field(Type, field.name));
             try buffer.writer().print("    {s} = {s},\n\n", .{
-                stdx.to_case(field.name, .pascal),
+                stdx.to_case(field.name, .PascalCase),
                 if (int_value == std.math.maxInt(@TypeOf(int_value)))
                     std.fmt.comptimePrint("0x{X}", .{int_value})
                 else
@@ -316,7 +316,7 @@ fn emit_struct(
                     \\
                     \\
                 , .{
-                    .name = stdx.to_case(field.name, .pascal),
+                    .name = stdx.to_case(field.name, .PascalCase),
                     .size = array.len * @sizeOf(array.child),
                     .len = array.len,
                     .child_type = dotnet_type(array.child),
@@ -338,8 +338,8 @@ fn emit_struct(
             ,
                 .{
                     if (mapping.visibility == .internal and !is_private) "public" else "private",
-                    stdx.to_case(field.name, .pascal),
-                    stdx.to_case(field.name, .camel),
+                    stdx.to_case(field.name, .PascalCase),
+                    stdx.to_case(field.name, .camelCase),
                 },
             ),
             else => try buffer.writer().print(
@@ -350,7 +350,7 @@ fn emit_struct(
                 .{
                     if (mapping.visibility == .internal and !is_private) "public" else "private",
                     dotnet_type(field.type),
-                    stdx.to_case(field.name, .camel),
+                    stdx.to_case(field.name, .camelCase),
                 },
             ),
         }
@@ -372,10 +372,10 @@ fn emit_struct(
                     \\
                 , .{
                     if (is_private) "internal" else "public",
-                    stdx.to_case(field.name, .pascal),
-                    stdx.to_case(field.name, .camel),
+                    stdx.to_case(field.name, .PascalCase),
+                    stdx.to_case(field.name, .camelCase),
                     if (is_read_only and !is_private) "internal " else "",
-                    stdx.to_case(field.name, .camel),
+                    stdx.to_case(field.name, .camelCase),
                 }),
                 else => try buffer.writer().print(
                     \\    {s} {s} {s} {{ get => {s}; {s}set => {s} = value; }}
@@ -384,10 +384,10 @@ fn emit_struct(
                 , .{
                     if (is_private) "internal" else "public",
                     dotnet_type(field.type),
-                    stdx.to_case(field.name, .pascal),
-                    stdx.to_case(field.name, .camel),
+                    stdx.to_case(field.name, .PascalCase),
+                    stdx.to_case(field.name, .camelCase),
                     if (is_read_only and !is_private) "internal " else "",
-                    stdx.to_case(field.name, .camel),
+                    stdx.to_case(field.name, .camelCase),
                 }),
             }
         }

--- a/src/clients/dotnet/dotnet_bindings.zig
+++ b/src/clients/dotnet/dotnet_bindings.zig
@@ -190,26 +190,6 @@ fn get_mapped_type_name(comptime Type: type) ?[]const u8 {
     } else return null;
 }
 
-fn to_case(comptime input: []const u8, comptime case: enum { camel, pascal }) []const u8 {
-    return comptime blk: {
-        var len: usize = 0;
-        var output: [input.len]u8 = undefined;
-        var iterator = std.mem.tokenizeScalar(u8, input, '_');
-        while (iterator.next()) |word| {
-            _ = std.ascii.lowerString(output[len..], word);
-            output[len] = std.ascii.toUpper(output[len]);
-            len += word.len;
-        }
-
-        output[0] = switch (case) {
-            .camel => std.ascii.toLower(output[0]),
-            .pascal => std.ascii.toUpper(output[0]),
-        };
-
-        break :blk stdx.comptime_slice(&output, len);
-    };
-}
-
 fn emit_enum(
     buffer: *std.ArrayList(u8),
     comptime Type: type,
@@ -250,13 +230,13 @@ fn emit_enum(
         try emit_docs(buffer, mapping, field.name);
         if (is_packed_struct) {
             try buffer.writer().print("    {s} = 1 << {},\n\n", .{
-                to_case(field.name, .pascal),
+                stdx.to_case(field.name, .pascal),
                 i,
             });
         } else {
             const int_value = @intFromEnum(@field(Type, field.name));
             try buffer.writer().print("    {s} = {s},\n\n", .{
-                to_case(field.name, .pascal),
+                stdx.to_case(field.name, .pascal),
                 if (int_value == std.math.maxInt(@TypeOf(int_value)))
                     std.fmt.comptimePrint("0x{X}", .{int_value})
                 else
@@ -336,7 +316,7 @@ fn emit_struct(
                     \\
                     \\
                 , .{
-                    .name = to_case(field.name, .pascal),
+                    .name = stdx.to_case(field.name, .pascal),
                     .size = array.len * @sizeOf(array.child),
                     .len = array.len,
                     .child_type = dotnet_type(array.child),
@@ -358,8 +338,8 @@ fn emit_struct(
             ,
                 .{
                     if (mapping.visibility == .internal and !is_private) "public" else "private",
-                    to_case(field.name, .pascal),
-                    to_case(field.name, .camel),
+                    stdx.to_case(field.name, .pascal),
+                    stdx.to_case(field.name, .camel),
                 },
             ),
             else => try buffer.writer().print(
@@ -370,7 +350,7 @@ fn emit_struct(
                 .{
                     if (mapping.visibility == .internal and !is_private) "public" else "private",
                     dotnet_type(field.type),
-                    to_case(field.name, .camel),
+                    stdx.to_case(field.name, .camel),
                 },
             ),
         }
@@ -392,10 +372,10 @@ fn emit_struct(
                     \\
                 , .{
                     if (is_private) "internal" else "public",
-                    to_case(field.name, .pascal),
-                    to_case(field.name, .camel),
+                    stdx.to_case(field.name, .pascal),
+                    stdx.to_case(field.name, .camel),
                     if (is_read_only and !is_private) "internal " else "",
-                    to_case(field.name, .camel),
+                    stdx.to_case(field.name, .camel),
                 }),
                 else => try buffer.writer().print(
                     \\    {s} {s} {s} {{ get => {s}; {s}set => {s} = value; }}
@@ -404,10 +384,10 @@ fn emit_struct(
                 , .{
                     if (is_private) "internal" else "public",
                     dotnet_type(field.type),
-                    to_case(field.name, .pascal),
-                    to_case(field.name, .camel),
+                    stdx.to_case(field.name, .pascal),
+                    stdx.to_case(field.name, .camel),
                     if (is_read_only and !is_private) "internal " else "",
-                    to_case(field.name, .camel),
+                    stdx.to_case(field.name, .camel),
                 }),
             }
         }

--- a/src/clients/java/java_bindings.zig
+++ b/src/clients/java/java_bindings.zig
@@ -248,7 +248,7 @@ fn emit_enum(
             \\    {[enum_name]s}(({[int_type]s}) {[value]s}){[separator]c}
             \\
         , .{
-            .enum_name = stdx.to_case(field.name, .pascal),
+            .enum_name = stdx.to_case(field.name, .PascalCase),
             .int_type = int_type,
             .value = if (int_value == std.math.maxInt(@TypeOf(int_value)))
                 std.fmt.comptimePrint("0x{X}", .{int_value})
@@ -280,7 +280,7 @@ fn emit_enum(
             \\            case {[value]s}: return {[enum_name]s};
             \\
         , .{
-            .enum_name = stdx.to_case(field.name, .pascal),
+            .enum_name = stdx.to_case(field.name, .PascalCase),
             .value = if (int_value == std.math.maxInt(@TypeOf(int_value)))
                 std.fmt.comptimePrint("0x{X}", .{int_value})
             else
@@ -342,7 +342,7 @@ fn emit_packed_enum(
             \\
         , .{
             .int_type = int_type,
-            .enum_name = stdx.to_case(field.name, .upper),
+            .enum_name = stdx.to_case(field.name, .UPPER_CASE),
             .value = i,
         });
     }
@@ -359,9 +359,9 @@ fn emit_packed_enum(
             \\
             \\
         , .{
-            .flag_name = stdx.to_case(field.name, .pascal),
+            .flag_name = stdx.to_case(field.name, .PascalCase),
             .int_type = int_type,
-            .enum_name = stdx.to_case(field.name, .upper),
+            .enum_name = stdx.to_case(field.name, .UPPER_CASE),
         });
     }
 
@@ -432,7 +432,7 @@ fn emit_batch(
             \\        int {[field_name]s} = {[offset]d};
             \\
         , .{
-            .field_name = stdx.to_case(field.name, .pascal),
+            .field_name = stdx.to_case(field.name, .PascalCase),
             .offset = offset,
         });
 
@@ -522,7 +522,7 @@ fn emit_batch_accessors(
             \\
         , .{
             .visibility = if (is_private) "" else "public ",
-            .property = stdx.to_case(field.name, .pascal),
+            .property = stdx.to_case(field.name, .PascalCase),
             .array_len = @typeInfo(field.type).array.len,
         });
     } else {
@@ -536,7 +536,7 @@ fn emit_batch_accessors(
         , .{
             .visibility = if (is_private) "" else "public ",
             .java_type = java_type(field.type),
-            .property = stdx.to_case(field.name, .pascal),
+            .property = stdx.to_case(field.name, .PascalCase),
             .batch_type = batch_type(field.type),
             .return_expression = comptime if (@typeInfo(field.type) == .@"enum")
                 get_mapped_type_name(field.type).? ++ ".fromValue(value)"
@@ -553,7 +553,7 @@ fn emit_batch_accessors(
         \\     * @throws IllegalStateException if a {{@link #isReadOnly() read-only}} batch.
         \\
     , .{
-        .param_name = stdx.to_case(field.name, .camel),
+        .param_name = stdx.to_case(field.name, .camelCase),
     });
 
     if (mapping.docs_link) |docs_link| {
@@ -584,8 +584,8 @@ fn emit_batch_accessors(
             \\
             \\
         , .{
-            .property = stdx.to_case(field.name, .pascal),
-            .param_name = stdx.to_case(field.name, .camel),
+            .property = stdx.to_case(field.name, .PascalCase),
+            .param_name = stdx.to_case(field.name, .camelCase),
             .visibility = if (is_private or is_read_only) "" else "public ",
             .array_len = @typeInfo(field.type).array.len,
         });
@@ -597,8 +597,8 @@ fn emit_batch_accessors(
             \\
             \\
         , .{
-            .property = stdx.to_case(field.name, .pascal),
-            .param_name = stdx.to_case(field.name, .camel),
+            .property = stdx.to_case(field.name, .PascalCase),
+            .param_name = stdx.to_case(field.name, .camelCase),
             .visibility = if (is_private or is_read_only) "" else "public ",
             .batch_type = batch_type(field.type),
             .java_type = java_type(field.type),
@@ -659,7 +659,7 @@ fn emit_u128_batch_accessors(
             \\
         , .{
             .visibility = if (is_private) "" else "public ",
-            .property = stdx.to_case(field.name, .pascal),
+            .property = stdx.to_case(field.name, .PascalCase),
         });
     } else {
         // Get array:
@@ -694,7 +694,7 @@ fn emit_u128_batch_accessors(
             \\
         , .{
             .visibility = if (is_private) "" else "public ",
-            .property = stdx.to_case(field.name, .pascal),
+            .property = stdx.to_case(field.name, .PascalCase),
         });
     }
 
@@ -734,7 +734,7 @@ fn emit_u128_batch_accessors(
         \\
     , .{
         .visibility = if (is_private) "" else "public ",
-        .property = stdx.to_case(field.name, .pascal),
+        .property = stdx.to_case(field.name, .PascalCase),
     });
 
     if (big_integer.contains(field.name)) {
@@ -746,7 +746,7 @@ fn emit_u128_batch_accessors(
             \\     * @throws IllegalStateException if a {{@link #isReadOnly() read-only}} batch.
             \\
         , .{
-            .param_name = stdx.to_case(field.name, .camel),
+            .param_name = stdx.to_case(field.name, .camelCase),
         });
 
         if (mapping.docs_link) |docs_link| {
@@ -773,8 +773,8 @@ fn emit_u128_batch_accessors(
             \\
         , .{
             .visibility = if (is_private or is_read_only) "" else "public ",
-            .property = stdx.to_case(field.name, .pascal),
-            .param_name = stdx.to_case(field.name, .camel),
+            .property = stdx.to_case(field.name, .PascalCase),
+            .param_name = stdx.to_case(field.name, .camelCase),
         });
     } else {
         // Set array:
@@ -786,7 +786,7 @@ fn emit_u128_batch_accessors(
             \\     * @throws IllegalStateException if a {{@link #isReadOnly() read-only}} batch.
             \\
         , .{
-            .param_name = stdx.to_case(field.name, .camel),
+            .param_name = stdx.to_case(field.name, .camelCase),
         });
 
         if (mapping.docs_link) |docs_link| {
@@ -813,8 +813,8 @@ fn emit_u128_batch_accessors(
             \\
         , .{
             .visibility = if (is_private or is_read_only) "" else "public ",
-            .property = stdx.to_case(field.name, .pascal),
-            .param_name = stdx.to_case(field.name, .camel),
+            .property = stdx.to_case(field.name, .PascalCase),
+            .param_name = stdx.to_case(field.name, .camelCase),
         });
     }
 
@@ -852,7 +852,7 @@ fn emit_u128_batch_accessors(
         \\
     , .{
         .visibility = if (is_private or is_read_only) "" else "public ",
-        .property = stdx.to_case(field.name, .pascal),
+        .property = stdx.to_case(field.name, .PascalCase),
     });
 
     // Set long without most significant bits
@@ -888,7 +888,7 @@ fn emit_u128_batch_accessors(
         \\
     , .{
         .visibility = if (is_private or is_read_only) "" else "public ",
-        .property = stdx.to_case(field.name, .pascal),
+        .property = stdx.to_case(field.name, .PascalCase),
     });
 }
 

--- a/src/clients/java/java_bindings.zig
+++ b/src/clients/java/java_bindings.zig
@@ -199,35 +199,6 @@ fn get_mapped_type_name(comptime Type: type) ?[]const u8 {
     } else return null;
 }
 
-fn to_case(
-    comptime input: []const u8,
-    comptime case: enum { camel, pascal, upper },
-) []const u8 {
-    return comptime blk: {
-        var output: [input.len]u8 = undefined;
-        if (case == .upper) {
-            const len = std.ascii.upperString(output[0..], input).len;
-            break :blk stdx.comptime_slice(&output, len);
-        } else {
-            var len: usize = 0;
-            var iterator = std.mem.tokenizeScalar(u8, input, '_');
-            while (iterator.next()) |word| {
-                _ = std.ascii.lowerString(output[len..], word);
-                output[len] = std.ascii.toUpper(output[len]);
-                len += word.len;
-            }
-
-            output[0] = switch (case) {
-                .camel => std.ascii.toLower(output[0]),
-                .pascal => std.ascii.toUpper(output[0]),
-                .upper => unreachable,
-            };
-
-            break :blk stdx.comptime_slice(&output, len);
-        }
-    };
-}
-
 fn emit_enum(
     buffer: *std.ArrayList(u8),
     comptime Type: type,
@@ -277,7 +248,7 @@ fn emit_enum(
             \\    {[enum_name]s}(({[int_type]s}) {[value]s}){[separator]c}
             \\
         , .{
-            .enum_name = to_case(field.name, .pascal),
+            .enum_name = stdx.to_case(field.name, .pascal),
             .int_type = int_type,
             .value = if (int_value == std.math.maxInt(@TypeOf(int_value)))
                 std.fmt.comptimePrint("0x{X}", .{int_value})
@@ -309,7 +280,7 @@ fn emit_enum(
             \\            case {[value]s}: return {[enum_name]s};
             \\
         , .{
-            .enum_name = to_case(field.name, .pascal),
+            .enum_name = stdx.to_case(field.name, .pascal),
             .value = if (int_value == std.math.maxInt(@TypeOf(int_value)))
                 std.fmt.comptimePrint("0x{X}", .{int_value})
             else
@@ -371,7 +342,7 @@ fn emit_packed_enum(
             \\
         , .{
             .int_type = int_type,
-            .enum_name = to_case(field.name, .upper),
+            .enum_name = stdx.to_case(field.name, .upper),
             .value = i,
         });
     }
@@ -388,9 +359,9 @@ fn emit_packed_enum(
             \\
             \\
         , .{
-            .flag_name = to_case(field.name, .pascal),
+            .flag_name = stdx.to_case(field.name, .pascal),
             .int_type = int_type,
-            .enum_name = to_case(field.name, .upper),
+            .enum_name = stdx.to_case(field.name, .upper),
         });
     }
 
@@ -461,7 +432,7 @@ fn emit_batch(
             \\        int {[field_name]s} = {[offset]d};
             \\
         , .{
-            .field_name = to_case(field.name, .pascal),
+            .field_name = stdx.to_case(field.name, .pascal),
             .offset = offset,
         });
 
@@ -551,7 +522,7 @@ fn emit_batch_accessors(
             \\
         , .{
             .visibility = if (is_private) "" else "public ",
-            .property = to_case(field.name, .pascal),
+            .property = stdx.to_case(field.name, .pascal),
             .array_len = @typeInfo(field.type).array.len,
         });
     } else {
@@ -565,7 +536,7 @@ fn emit_batch_accessors(
         , .{
             .visibility = if (is_private) "" else "public ",
             .java_type = java_type(field.type),
-            .property = to_case(field.name, .pascal),
+            .property = stdx.to_case(field.name, .pascal),
             .batch_type = batch_type(field.type),
             .return_expression = comptime if (@typeInfo(field.type) == .@"enum")
                 get_mapped_type_name(field.type).? ++ ".fromValue(value)"
@@ -582,7 +553,7 @@ fn emit_batch_accessors(
         \\     * @throws IllegalStateException if a {{@link #isReadOnly() read-only}} batch.
         \\
     , .{
-        .param_name = to_case(field.name, .camel),
+        .param_name = stdx.to_case(field.name, .camel),
     });
 
     if (mapping.docs_link) |docs_link| {
@@ -613,8 +584,8 @@ fn emit_batch_accessors(
             \\
             \\
         , .{
-            .property = to_case(field.name, .pascal),
-            .param_name = to_case(field.name, .camel),
+            .property = stdx.to_case(field.name, .pascal),
+            .param_name = stdx.to_case(field.name, .camel),
             .visibility = if (is_private or is_read_only) "" else "public ",
             .array_len = @typeInfo(field.type).array.len,
         });
@@ -626,8 +597,8 @@ fn emit_batch_accessors(
             \\
             \\
         , .{
-            .property = to_case(field.name, .pascal),
-            .param_name = to_case(field.name, .camel),
+            .property = stdx.to_case(field.name, .pascal),
+            .param_name = stdx.to_case(field.name, .camel),
             .visibility = if (is_private or is_read_only) "" else "public ",
             .batch_type = batch_type(field.type),
             .java_type = java_type(field.type),
@@ -688,7 +659,7 @@ fn emit_u128_batch_accessors(
             \\
         , .{
             .visibility = if (is_private) "" else "public ",
-            .property = to_case(field.name, .pascal),
+            .property = stdx.to_case(field.name, .pascal),
         });
     } else {
         // Get array:
@@ -723,7 +694,7 @@ fn emit_u128_batch_accessors(
             \\
         , .{
             .visibility = if (is_private) "" else "public ",
-            .property = to_case(field.name, .pascal),
+            .property = stdx.to_case(field.name, .pascal),
         });
     }
 
@@ -763,7 +734,7 @@ fn emit_u128_batch_accessors(
         \\
     , .{
         .visibility = if (is_private) "" else "public ",
-        .property = to_case(field.name, .pascal),
+        .property = stdx.to_case(field.name, .pascal),
     });
 
     if (big_integer.contains(field.name)) {
@@ -775,7 +746,7 @@ fn emit_u128_batch_accessors(
             \\     * @throws IllegalStateException if a {{@link #isReadOnly() read-only}} batch.
             \\
         , .{
-            .param_name = to_case(field.name, .camel),
+            .param_name = stdx.to_case(field.name, .camel),
         });
 
         if (mapping.docs_link) |docs_link| {
@@ -802,8 +773,8 @@ fn emit_u128_batch_accessors(
             \\
         , .{
             .visibility = if (is_private or is_read_only) "" else "public ",
-            .property = to_case(field.name, .pascal),
-            .param_name = to_case(field.name, .camel),
+            .property = stdx.to_case(field.name, .pascal),
+            .param_name = stdx.to_case(field.name, .camel),
         });
     } else {
         // Set array:
@@ -815,7 +786,7 @@ fn emit_u128_batch_accessors(
             \\     * @throws IllegalStateException if a {{@link #isReadOnly() read-only}} batch.
             \\
         , .{
-            .param_name = to_case(field.name, .camel),
+            .param_name = stdx.to_case(field.name, .camel),
         });
 
         if (mapping.docs_link) |docs_link| {
@@ -842,8 +813,8 @@ fn emit_u128_batch_accessors(
             \\
         , .{
             .visibility = if (is_private or is_read_only) "" else "public ",
-            .property = to_case(field.name, .pascal),
-            .param_name = to_case(field.name, .camel),
+            .property = stdx.to_case(field.name, .pascal),
+            .param_name = stdx.to_case(field.name, .camel),
         });
     }
 
@@ -881,7 +852,7 @@ fn emit_u128_batch_accessors(
         \\
     , .{
         .visibility = if (is_private or is_read_only) "" else "public ",
-        .property = to_case(field.name, .pascal),
+        .property = stdx.to_case(field.name, .pascal),
     });
 
     // Set long without most significant bits
@@ -917,7 +888,7 @@ fn emit_u128_batch_accessors(
         \\
     , .{
         .visibility = if (is_private or is_read_only) "" else "public ",
-        .property = to_case(field.name, .pascal),
+        .property = stdx.to_case(field.name, .pascal),
     });
 }
 

--- a/src/clients/python/python_bindings.zig
+++ b/src/clients/python/python_bindings.zig
@@ -164,7 +164,7 @@ fn emit_enum(
         }
 
         if (!skip) {
-            const field_name = stdx.to_case(field.name, .upper);
+            const field_name = stdx.to_case(field.name, .UPPER_CASE);
             if (@typeInfo(Type) == .@"enum") {
                 const int_value = @intFromEnum(@field(Type, field.name));
                 buffer.print("    {s} = {s}\n", .{
@@ -316,7 +316,7 @@ fn emit_struct_dataclass(
                         // Enums - initialized with the default value.
                         buffer.print("{s}.{s}", .{
                             python_type,
-                            stdx.to_case(@tagName(@as(field.type, @enumFromInt(0))), .upper),
+                            stdx.to_case(@tagName(@as(field.type, @enumFromInt(0))), .UPPER_CASE),
                         });
                     } else {
                         // Simple integer types:
@@ -379,7 +379,7 @@ fn emit_method(
             .result_type = result_type,
             .event_name_or_list = event_name_or_list,
             .prefix_call = if (options.is_async) "await " else "",
-            .uppercase_name = stdx.to_case(@tagName(operation), .upper),
+            .uppercase_name = stdx.to_case(@tagName(operation), .UPPER_CASE),
             .event_type_c = ctype_type_name(operation.EventType()),
             .result_type_c = ctype_type_name(operation.ResultType()),
         },

--- a/src/clients/python/python_bindings.zig
+++ b/src/clients/python/python_bindings.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const vsr = @import("vsr");
 const exports = vsr.tb_client.exports;
 const assert = std.debug.assert;
+const stdx = vsr.stdx;
 
 const tb = vsr.tigerbeetle;
 
@@ -138,15 +139,6 @@ fn zig_to_python(comptime Type: type) []const u8 {
     }
 }
 
-fn to_uppercase(comptime input: []const u8) [input.len]u8 {
-    comptime var output: [input.len]u8 = undefined;
-    inline for (&output, 0..) |*char, i| {
-        char.* = input[i];
-        char.* -= 32 * @as(u8, @intFromBool(char.* >= 'a' and char.* <= 'z'));
-    }
-    return output;
-}
-
 fn emit_enum(
     buffer: *Buffer,
     comptime Type: type,
@@ -172,11 +164,11 @@ fn emit_enum(
         }
 
         if (!skip) {
-            const field_name = to_uppercase(field.name);
+            const field_name = stdx.to_case(field.name, .upper);
             if (@typeInfo(Type) == .@"enum") {
                 const int_value = @intFromEnum(@field(Type, field.name));
                 buffer.print("    {s} = {s}\n", .{
-                    @as([]const u8, &field_name),
+                    field_name,
                     if (int_value == std.math.maxInt(@TypeOf(int_value)))
                         std.fmt.comptimePrint("0x{X}", .{int_value})
                     else
@@ -185,7 +177,7 @@ fn emit_enum(
             } else {
                 // Packed structs.
                 buffer.print("    {s} = 1 << {}\n", .{
-                    @as([]const u8, &field_name),
+                    field_name,
                     i,
                 });
             }
@@ -324,7 +316,7 @@ fn emit_struct_dataclass(
                         // Enums - initialized with the default value.
                         buffer.print("{s}.{s}", .{
                             python_type,
-                            to_uppercase(@tagName(@as(field.type, @enumFromInt(0)))),
+                            stdx.to_case(@tagName(@as(field.type, @enumFromInt(0))), .upper),
                         });
                     } else {
                         // Simple integer types:
@@ -387,7 +379,7 @@ fn emit_method(
             .result_type = result_type,
             .event_name_or_list = event_name_or_list,
             .prefix_call = if (options.is_async) "await " else "",
-            .uppercase_name = to_uppercase(@tagName(operation)),
+            .uppercase_name = stdx.to_case(@tagName(operation), .upper),
             .event_type_c = ctype_type_name(operation.EventType()),
             .result_type_c = ctype_type_name(operation.ResultType()),
         },

--- a/src/clients/ruby/ruby_bindings.zig
+++ b/src/clients/ruby/ruby_bindings.zig
@@ -5,6 +5,7 @@ const generator_options = @import("ruby_bindings_options");
 const vsr = @import("vsr");
 const exports = vsr.tb_client.exports;
 const tb = vsr.tigerbeetle;
+const stdx = vsr.stdx;
 
 const flag_mappings = .{
     .{ tb.AccountFlags, "AccountFlags" },
@@ -29,15 +30,6 @@ const Buffer = struct {
     }
 };
 
-fn to_upper_snake(comptime input: []const u8) [input.len]u8 {
-    comptime var output: [input.len]u8 = undefined;
-    inline for (&output, 0..) |*c, i| {
-        c.* = input[i];
-        c.* -= 32 * @as(u8, @intFromBool(c.* >= 'a' and c.* <= 'z'));
-    }
-    return output;
-}
-
 fn ruby_flags_name_from_type(comptime Type: type) ?[]const u8 {
     comptime for (flag_mappings) |mapping| {
         const ZigType, const ruby_name = mapping;
@@ -47,12 +39,12 @@ fn ruby_flags_name_from_type(comptime Type: type) ?[]const u8 {
 }
 
 fn c_operation_name(comptime operation: tb.Operation) []const u8 {
-    const upper_snake = to_upper_snake(@tagName(operation));
+    const upper_snake = stdx.to_case(@tagName(operation), .upper);
     return "TB_OPERATION_" ++ upper_snake;
 }
 
 fn c_init_status_name(comptime status: exports.tb_init_status) []const u8 {
-    const upper_snake = to_upper_snake(@tagName(status));
+    const upper_snake = stdx.to_case(@tagName(status), .upper);
     return "TB_INIT_" ++ upper_snake;
 }
 
@@ -147,8 +139,8 @@ fn emit_flags_module(
     inline for (@typeInfo(Type).@"struct".fields, 0..) |field, i| {
         if (comptime std.mem.startsWith(u8, field.name, "deprecated_")) continue;
         if (comptime std.mem.eql(u8, field.name, "padding")) continue;
-        const upper_snake = to_upper_snake(field.name);
-        buffer.print("    {s} = 1 << {d}\n", .{ @as([]const u8, &upper_snake), i });
+        const upper_snake = stdx.to_case(field.name, .upper);
+        buffer.print("    {s} = 1 << {d}\n", .{ upper_snake, i });
     }
     buffer.print("  end\n\n", .{});
 }
@@ -169,9 +161,9 @@ fn emit_enum_module(
             skip = skip or comptime std.mem.eql(u8, sf, field.name);
         }
         if (skip) continue;
-        const upper_snake = to_upper_snake(field.name);
+        const upper_snake = stdx.to_case(field.name, .upper);
         const value: u64 = @intCast(@intFromEnum(@field(Type, field.name)));
-        buffer.print("    {s} = {d}\n", .{ @as([]const u8, &upper_snake), value });
+        buffer.print("    {s} = {d}\n", .{ upper_snake, value });
     }
     buffer.print("  end\n\n", .{});
 }
@@ -250,8 +242,8 @@ fn emit_rbs_constants_module(
             inline for (info.fields) |field| {
                 if (comptime std.mem.startsWith(u8, field.name, "deprecated_")) continue;
                 if (comptime std.mem.eql(u8, field.name, "padding")) continue;
-                const upper_snake = to_upper_snake(field.name);
-                buffer.print("    {s}: Integer\n", .{@as([]const u8, &upper_snake)});
+                const upper_snake = stdx.to_case(field.name, .upper);
+                buffer.print("    {s}: Integer\n", .{upper_snake});
             }
         },
         .@"enum" => |info| {
@@ -262,8 +254,8 @@ fn emit_rbs_constants_module(
                     skip = skip or comptime std.mem.eql(u8, sf, field.name);
                 }
                 if (skip) continue;
-                const upper_snake = to_upper_snake(field.name);
-                buffer.print("    {s}: Integer\n", .{@as([]const u8, &upper_snake)});
+                const upper_snake = stdx.to_case(field.name, .upper);
+                buffer.print("    {s}: Integer\n", .{upper_snake});
             }
         },
         else => @compileError("unsupported RBS constants module type: " ++ @typeName(Type)),

--- a/src/clients/ruby/ruby_bindings.zig
+++ b/src/clients/ruby/ruby_bindings.zig
@@ -39,12 +39,12 @@ fn ruby_flags_name_from_type(comptime Type: type) ?[]const u8 {
 }
 
 fn c_operation_name(comptime operation: tb.Operation) []const u8 {
-    const upper_snake = stdx.to_case(@tagName(operation), .upper);
+    const upper_snake = stdx.to_case(@tagName(operation), .UPPER_CASE);
     return "TB_OPERATION_" ++ upper_snake;
 }
 
 fn c_init_status_name(comptime status: exports.tb_init_status) []const u8 {
-    const upper_snake = stdx.to_case(@tagName(status), .upper);
+    const upper_snake = stdx.to_case(@tagName(status), .UPPER_CASE);
     return "TB_INIT_" ++ upper_snake;
 }
 
@@ -139,7 +139,7 @@ fn emit_flags_module(
     inline for (@typeInfo(Type).@"struct".fields, 0..) |field, i| {
         if (comptime std.mem.startsWith(u8, field.name, "deprecated_")) continue;
         if (comptime std.mem.eql(u8, field.name, "padding")) continue;
-        const upper_snake = stdx.to_case(field.name, .upper);
+        const upper_snake = stdx.to_case(field.name, .UPPER_CASE);
         buffer.print("    {s} = 1 << {d}\n", .{ upper_snake, i });
     }
     buffer.print("  end\n\n", .{});
@@ -161,7 +161,7 @@ fn emit_enum_module(
             skip = skip or comptime std.mem.eql(u8, sf, field.name);
         }
         if (skip) continue;
-        const upper_snake = stdx.to_case(field.name, .upper);
+        const upper_snake = stdx.to_case(field.name, .UPPER_CASE);
         const value: u64 = @intCast(@intFromEnum(@field(Type, field.name)));
         buffer.print("    {s} = {d}\n", .{ upper_snake, value });
     }
@@ -242,7 +242,7 @@ fn emit_rbs_constants_module(
             inline for (info.fields) |field| {
                 if (comptime std.mem.startsWith(u8, field.name, "deprecated_")) continue;
                 if (comptime std.mem.eql(u8, field.name, "padding")) continue;
-                const upper_snake = stdx.to_case(field.name, .upper);
+                const upper_snake = stdx.to_case(field.name, .UPPER_CASE);
                 buffer.print("    {s}: Integer\n", .{upper_snake});
             }
         },
@@ -254,7 +254,7 @@ fn emit_rbs_constants_module(
                     skip = skip or comptime std.mem.eql(u8, sf, field.name);
                 }
                 if (skip) continue;
-                const upper_snake = stdx.to_case(field.name, .upper);
+                const upper_snake = stdx.to_case(field.name, .UPPER_CASE);
                 buffer.print("    {s}: Integer\n", .{upper_snake});
             }
         },

--- a/src/clients/rust/rust_bindings.zig
+++ b/src/clients/rust/rust_bindings.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const vsr = @import("vsr");
 const exports = vsr.tb_client.exports;
 const assert = std.debug.assert;
+const stdx = vsr.stdx;
 
 const type_mappings = .{
     .{ exports.tb_account_flags, "TB_ACCOUNT_FLAGS" },
@@ -78,15 +79,6 @@ fn resolve_rust_type(comptime Type: type) []const u8 {
     }
 }
 
-fn to_uppercase(comptime input: []const u8) [input.len]u8 {
-    comptime var output: [input.len]u8 = undefined;
-    inline for (&output, 0..) |*char, i| {
-        char.* = input[i];
-        char.* -= 32 * @as(u8, @intFromBool(char.* >= 'a' and char.* <= 'z'));
-    }
-    return output;
-}
-
 fn emit_enum(
     buffer: *std.ArrayList(u8),
     comptime Type: type,
@@ -127,13 +119,13 @@ fn emit_enum(
         }
 
         if (!skip) {
-            const field_name = to_uppercase(field.name);
+            const field_name = stdx.to_case(field.name, .upper);
             if (@typeInfo(Type) == .@"enum") {
                 const int_value = @intFromEnum(@field(Type, field.name));
                 try buffer.writer().print("pub const {s}_{s}_{s}: {s} = {s};\n", .{
                     rust_name,
                     rust_name[0..suffix_pos],
-                    @as([]const u8, &field_name),
+                    field_name,
                     rust_name,
                     if (int_value == std.math.maxInt(@TypeOf(int_value)))
                         std.fmt.comptimePrint("0x{X}", .{int_value})
@@ -145,7 +137,7 @@ fn emit_enum(
                 try buffer.writer().print("pub const {s}_{s}_{s}: {s} = 1 << {};\n", .{
                     rust_name,
                     rust_name[0..suffix_pos],
-                    @as([]const u8, &field_name),
+                    field_name,
                     rust_name,
                     i,
                 });

--- a/src/clients/rust/rust_bindings.zig
+++ b/src/clients/rust/rust_bindings.zig
@@ -119,7 +119,7 @@ fn emit_enum(
         }
 
         if (!skip) {
-            const field_name = stdx.to_case(field.name, .upper);
+            const field_name = stdx.to_case(field.name, .UPPER_CASE);
             if (@typeInfo(Type) == .@"enum") {
                 const int_value = @intFromEnum(@field(Type, field.name));
                 try buffer.writer().print("pub const {s}_{s}_{s}: {s} = {s};\n", .{

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1194,6 +1194,53 @@ pub fn term_from_status(status: u32) std.process.Child.Term {
         Term{ .Unknown = status };
 }
 
+/// Converts a snake_case identifier to another identifier case at comptime.
+pub fn to_case(
+    comptime input: []const u8,
+    comptime case: enum { camel, kebab, pascal, upper },
+) []const u8 {
+    return comptime blk: {
+        var output: [input.len]u8 = undefined;
+        switch (case) {
+            .kebab => {
+                for (input, 0..) |byte, index| output[index] = if (byte == '_') '-' else byte;
+                break :blk comptime_slice(&output, input.len);
+            },
+            .upper => {
+                const len = std.ascii.upperString(output[0..], input).len;
+                break :blk comptime_slice(&output, len);
+            },
+            .camel, .pascal => {
+                var len: usize = 0;
+                var iterator = std.mem.tokenizeScalar(u8, input, '_');
+                while (iterator.next()) |word| {
+                    _ = std.ascii.lowerString(output[len..], word);
+                    output[len] = std.ascii.toUpper(output[len]);
+                    len += word.len;
+                }
+
+                output[0] = switch (case) {
+                    .camel => std.ascii.toLower(output[0]),
+                    .pascal => std.ascii.toUpper(output[0]),
+                    .kebab, .upper => unreachable,
+                };
+
+                break :blk comptime_slice(&output, len);
+            },
+        }
+    };
+}
+
+test "to_case" {
+    try std.testing.expectEqualStrings("createAccounts", to_case("create_accounts", .camel));
+    try std.testing.expectEqualStrings("CreateTransfers", to_case("create_transfers", .pascal));
+    try std.testing.expectEqualStrings("user-data-128", to_case("user_data_128", .kebab));
+    try std.testing.expectEqualStrings(
+        "GET_ACCOUNT_BALANCES",
+        to_case("get_account_balances", .upper),
+    );
+}
+
 comptime {
     _ = @import("bit_set.zig");
     _ = @import("bounded_array.zig");

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1196,23 +1196,23 @@ pub fn term_from_status(status: u32) std.process.Child.Term {
 
 /// Converts a snake_case identifier to another identifier case at comptime.
 pub fn to_case(
-    comptime input: []const u8,
-    comptime case: enum { camel, kebab, pascal, upper },
+    comptime snake_case: []const u8,
+    comptime case: enum { camelCase, @"kebab-case", PascalCase, UPPER_CASE },
 ) []const u8 {
     return comptime blk: {
-        var output: [input.len]u8 = undefined;
+        var output: [snake_case.len]u8 = undefined;
         switch (case) {
-            .kebab => {
-                for (input, 0..) |byte, index| output[index] = if (byte == '_') '-' else byte;
-                break :blk comptime_slice(&output, input.len);
+            .@"kebab-case" => {
+                for (snake_case, 0..) |byte, index| output[index] = if (byte == '_') '-' else byte;
+                break :blk comptime_slice(&output, snake_case.len);
             },
-            .upper => {
-                const len = std.ascii.upperString(output[0..], input).len;
+            .UPPER_CASE => {
+                const len = std.ascii.upperString(output[0..], snake_case).len;
                 break :blk comptime_slice(&output, len);
             },
-            .camel, .pascal => {
+            .camelCase, .PascalCase => {
                 var len: usize = 0;
-                var iterator = std.mem.tokenizeScalar(u8, input, '_');
+                var iterator = std.mem.tokenizeScalar(u8, snake_case, '_');
                 while (iterator.next()) |word| {
                     _ = std.ascii.lowerString(output[len..], word);
                     output[len] = std.ascii.toUpper(output[len]);
@@ -1220,9 +1220,9 @@ pub fn to_case(
                 }
 
                 output[0] = switch (case) {
-                    .camel => std.ascii.toLower(output[0]),
-                    .pascal => std.ascii.toUpper(output[0]),
-                    .kebab, .upper => unreachable,
+                    .camelCase => std.ascii.toLower(output[0]),
+                    .PascalCase => std.ascii.toUpper(output[0]),
+                    .@"kebab-case", .UPPER_CASE => unreachable,
                 };
 
                 break :blk comptime_slice(&output, len);
@@ -1232,12 +1232,12 @@ pub fn to_case(
 }
 
 test "to_case" {
-    try std.testing.expectEqualStrings("createAccounts", to_case("create_accounts", .camel));
-    try std.testing.expectEqualStrings("CreateTransfers", to_case("create_transfers", .pascal));
-    try std.testing.expectEqualStrings("user-data-128", to_case("user_data_128", .kebab));
+    try std.testing.expectEqualStrings("createAccounts", to_case("create_accounts", .camelCase));
+    try std.testing.expectEqualStrings("CreateTransfers", to_case("create_transfers", .PascalCase));
+    try std.testing.expectEqualStrings("user-data-128", to_case("user_data_128", .@"kebab-case"));
     try std.testing.expectEqualStrings(
         "GET_ACCOUNT_BALANCES",
-        to_case("get_account_balances", .upper),
+        to_case("get_account_balances", .UPPER_CASE),
     );
 }
 


### PR DESCRIPTION
While researching my current project, I looked for an existing case-conversion function in the codebase. Turns out there's more than one. I don't mean to step on any toes, but I think it could make sense to unify (most of) them in `stdx`. 

This PR unifies the following functions:

- `kebab_case` in `src/cdc/amqp`
- `to_uppercase` in `src/clients/c/tb_client_header_test.zig`
- `to_uppercase` in `src/clients/c/tb_client_header.zig`
- `to_case` in `src/clients/dotnet/dotnet_bindings.zig`
- `to_case` in `src/clients/java/java_bindings.zig`
- `to_uppercase` in `src/clients/python/python_bindings.zig`
- `to_upper_snake` in `src/clients/ruby/ruby_bindings.zig`
- `to_uppercase` in `src/clients/rust/rust_bindings.zig`

The following functions have not been replaced:

- `to_pascal_case` in `src/clients/go/go_bindings.zig` because it has special handling for Go initialisms
- `to_snake_case` in `src/clients/ruby/ruby_bindings.zig` because it converts type names, not identifier names

I ran all generators locally. They didn't generate any diffs.