### PR TITLE
clients/ruby: Validate u128 bounds

### DIFF
--- a/src/clients/ruby/ruby_bindings.zig
+++ b/src/clients/ruby/ruby_bindings.zig
@@ -117,17 +117,6 @@ fn int_bits(comptime Type: type) comptime_int {
     };
 }
 
-fn c_uint_type(comptime bits: comptime_int) []const u8 {
-    return switch (bits) {
-        8 => "uint8_t",
-        16 => "uint16_t",
-        32 => "uint32_t",
-        64 => "uint64_t",
-        128 => "tb_uint128_t",
-        else => @compileError("unsupported integer width"),
-    };
-}
-
 fn field_reserved(comptime field_name: []const u8) bool {
     if (comptime std.mem.eql(u8, field_name, "reserved")) return true;
     if (comptime std.mem.eql(u8, field_name, "padding")) return true;
@@ -493,7 +482,9 @@ fn emit_c_num_from_ruby(
 ) void {
     const bits = comptime int_bits(FieldType);
     switch (bits) {
-        8, 16, 32 => buffer.print("({s})NUM2UINT({s})", .{ c_uint_type(bits), ruby_value }),
+        8 => buffer.print("NUM2CHR({s})", .{ruby_value}),
+        16 => buffer.print("NUM2USHORT({s})", .{ruby_value}),
+        32 => buffer.print("NUM2UINT({s})", .{ruby_value}),
         64 => buffer.print("NUM2ULL({s})", .{ruby_value}),
         else => @compileError("unsupported Ruby numeric field"),
     }

--- a/src/clients/ruby/ruby_bindings.zig
+++ b/src/clients/ruby/ruby_bindings.zig
@@ -482,10 +482,10 @@ fn emit_c_num_from_ruby(
 ) void {
     const bits = comptime int_bits(FieldType);
     switch (bits) {
-        8 => buffer.print("NUM2CHR({s})", .{ruby_value}),
-        16 => buffer.print("NUM2USHORT({s})", .{ruby_value}),
-        32 => buffer.print("NUM2UINT({s})", .{ruby_value}),
-        64 => buffer.print("NUM2ULL({s})", .{ruby_value}),
+        8 => buffer.print("RB_NUM2CHR({s})", .{ruby_value}),
+        16 => buffer.print("RB_NUM2USHORT({s})", .{ruby_value}),
+        32 => buffer.print("RB_NUM2UINT({s})", .{ruby_value}),
+        64 => buffer.print("RB_NUM2ULL({s})", .{ruby_value}),
         else => @compileError("unsupported Ruby numeric field"),
     }
 }
@@ -497,8 +497,8 @@ fn emit_c_value_from_field(
 ) void {
     const bits = comptime int_bits(FieldType);
     switch (bits) {
-        8, 16, 32 => buffer.print("UINT2NUM({s})", .{field_expr}),
-        64 => buffer.print("ULL2NUM({s})", .{field_expr}),
+        8, 16, 32 => buffer.print("RB_UINT2NUM({s})", .{field_expr}),
+        64 => buffer.print("RB_ULL2NUM({s})", .{field_expr}),
         128 => buffer.print("rb_tb_unpack_u128(&{s})", .{field_expr}),
         else => @compileError("unsupported C numeric field"),
     }

--- a/src/clients/ruby/ruby_bindings.zig
+++ b/src/clients/ruby/ruby_bindings.zig
@@ -438,7 +438,10 @@ fn emit_c_header_preamble(buffer: *Buffer) void {
         \\#include <string.h>
         \\
         \\static inline void rb_tb_pack_u128(VALUE v, void *dst) {
-        \\    rb_integer_pack(v, dst, 16, 1, 0, INTEGER_PACK_LITTLE_ENDIAN);
+        \\    int status = rb_integer_pack(v, dst, 16, 1, 0, INTEGER_PACK_LITTLE_ENDIAN);
+        \\    if (status != 0 && status != 1) {
+        \\        rb_raise(rb_eRangeError, "integer must be between 0 and 2**128 - 1");
+        \\    }
         \\}
         \\
         \\static inline VALUE rb_tb_unpack_u128(const void *src) {

--- a/src/clients/ruby/src/ext/tigerbeetle/rb_tb_gen.h
+++ b/src/clients/ruby/src/ext/tigerbeetle/rb_tb_gen.h
@@ -76,13 +76,13 @@ static VALUE rb_tb_deserialize_lookup_accounts(const uint8_t *buf, uint32_t buf_
         rb_ivar_set(obj, rb_intern("@credits_pending"), rb_tb_unpack_u128(&item->credits_pending));
         rb_ivar_set(obj, rb_intern("@credits_posted"), rb_tb_unpack_u128(&item->credits_posted));
         rb_ivar_set(obj, rb_intern("@user_data_128"), rb_tb_unpack_u128(&item->user_data_128));
-        rb_ivar_set(obj, rb_intern("@user_data_64"), ULL2NUM(item->user_data_64));
-        rb_ivar_set(obj, rb_intern("@user_data_32"), UINT2NUM(item->user_data_32));
+        rb_ivar_set(obj, rb_intern("@user_data_64"), RB_ULL2NUM(item->user_data_64));
+        rb_ivar_set(obj, rb_intern("@user_data_32"), RB_UINT2NUM(item->user_data_32));
         tb_assert(item->reserved == 0);
-        rb_ivar_set(obj, rb_intern("@ledger"), UINT2NUM(item->ledger));
-        rb_ivar_set(obj, rb_intern("@code"), UINT2NUM(item->code));
-        rb_ivar_set(obj, rb_intern("@flags"), UINT2NUM(item->flags));
-        rb_ivar_set(obj, rb_intern("@timestamp"), ULL2NUM(item->timestamp));
+        rb_ivar_set(obj, rb_intern("@ledger"), RB_UINT2NUM(item->ledger));
+        rb_ivar_set(obj, rb_intern("@code"), RB_UINT2NUM(item->code));
+        rb_ivar_set(obj, rb_intern("@flags"), RB_UINT2NUM(item->flags));
+        rb_ivar_set(obj, rb_intern("@timestamp"), RB_ULL2NUM(item->timestamp));
         rb_ary_push(results, obj);
     }
     return results;
@@ -103,13 +103,13 @@ static VALUE rb_tb_deserialize_lookup_transfers(const uint8_t *buf, uint32_t buf
         rb_ivar_set(obj, rb_intern("@amount"), rb_tb_unpack_u128(&item->amount));
         rb_ivar_set(obj, rb_intern("@pending_id"), rb_tb_unpack_u128(&item->pending_id));
         rb_ivar_set(obj, rb_intern("@user_data_128"), rb_tb_unpack_u128(&item->user_data_128));
-        rb_ivar_set(obj, rb_intern("@user_data_64"), ULL2NUM(item->user_data_64));
-        rb_ivar_set(obj, rb_intern("@user_data_32"), UINT2NUM(item->user_data_32));
-        rb_ivar_set(obj, rb_intern("@timeout"), UINT2NUM(item->timeout));
-        rb_ivar_set(obj, rb_intern("@ledger"), UINT2NUM(item->ledger));
-        rb_ivar_set(obj, rb_intern("@code"), UINT2NUM(item->code));
-        rb_ivar_set(obj, rb_intern("@flags"), UINT2NUM(item->flags));
-        rb_ivar_set(obj, rb_intern("@timestamp"), ULL2NUM(item->timestamp));
+        rb_ivar_set(obj, rb_intern("@user_data_64"), RB_ULL2NUM(item->user_data_64));
+        rb_ivar_set(obj, rb_intern("@user_data_32"), RB_UINT2NUM(item->user_data_32));
+        rb_ivar_set(obj, rb_intern("@timeout"), RB_UINT2NUM(item->timeout));
+        rb_ivar_set(obj, rb_intern("@ledger"), RB_UINT2NUM(item->ledger));
+        rb_ivar_set(obj, rb_intern("@code"), RB_UINT2NUM(item->code));
+        rb_ivar_set(obj, rb_intern("@flags"), RB_UINT2NUM(item->flags));
+        rb_ivar_set(obj, rb_intern("@timestamp"), RB_ULL2NUM(item->timestamp));
         rb_ary_push(results, obj);
     }
     return results;
@@ -122,14 +122,14 @@ static void rb_tb_serialize_get_account_transfers(VALUE items_rb, uint8_t *buf, 
         tb_account_filter_t *item = &items[i];
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@account_id")), &item->account_id);
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
+        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
         memset(item->reserved, 0, sizeof(item->reserved));
-        item->timestamp_min = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
-        item->timestamp_max = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->timestamp_min = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
+        item->timestamp_max = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
+        item->limit = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
+        item->flags = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
     }
 }
 
@@ -148,13 +148,13 @@ static VALUE rb_tb_deserialize_get_account_transfers(const uint8_t *buf, uint32_
         rb_ivar_set(obj, rb_intern("@amount"), rb_tb_unpack_u128(&item->amount));
         rb_ivar_set(obj, rb_intern("@pending_id"), rb_tb_unpack_u128(&item->pending_id));
         rb_ivar_set(obj, rb_intern("@user_data_128"), rb_tb_unpack_u128(&item->user_data_128));
-        rb_ivar_set(obj, rb_intern("@user_data_64"), ULL2NUM(item->user_data_64));
-        rb_ivar_set(obj, rb_intern("@user_data_32"), UINT2NUM(item->user_data_32));
-        rb_ivar_set(obj, rb_intern("@timeout"), UINT2NUM(item->timeout));
-        rb_ivar_set(obj, rb_intern("@ledger"), UINT2NUM(item->ledger));
-        rb_ivar_set(obj, rb_intern("@code"), UINT2NUM(item->code));
-        rb_ivar_set(obj, rb_intern("@flags"), UINT2NUM(item->flags));
-        rb_ivar_set(obj, rb_intern("@timestamp"), ULL2NUM(item->timestamp));
+        rb_ivar_set(obj, rb_intern("@user_data_64"), RB_ULL2NUM(item->user_data_64));
+        rb_ivar_set(obj, rb_intern("@user_data_32"), RB_UINT2NUM(item->user_data_32));
+        rb_ivar_set(obj, rb_intern("@timeout"), RB_UINT2NUM(item->timeout));
+        rb_ivar_set(obj, rb_intern("@ledger"), RB_UINT2NUM(item->ledger));
+        rb_ivar_set(obj, rb_intern("@code"), RB_UINT2NUM(item->code));
+        rb_ivar_set(obj, rb_intern("@flags"), RB_UINT2NUM(item->flags));
+        rb_ivar_set(obj, rb_intern("@timestamp"), RB_ULL2NUM(item->timestamp));
         rb_ary_push(results, obj);
     }
     return results;
@@ -167,14 +167,14 @@ static void rb_tb_serialize_get_account_balances(VALUE items_rb, uint8_t *buf, l
         tb_account_filter_t *item = &items[i];
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@account_id")), &item->account_id);
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
+        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
         memset(item->reserved, 0, sizeof(item->reserved));
-        item->timestamp_min = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
-        item->timestamp_max = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->timestamp_min = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
+        item->timestamp_max = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
+        item->limit = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
+        item->flags = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
     }
 }
 
@@ -191,7 +191,7 @@ static VALUE rb_tb_deserialize_get_account_balances(const uint8_t *buf, uint32_t
         rb_ivar_set(obj, rb_intern("@debits_posted"), rb_tb_unpack_u128(&item->debits_posted));
         rb_ivar_set(obj, rb_intern("@credits_pending"), rb_tb_unpack_u128(&item->credits_pending));
         rb_ivar_set(obj, rb_intern("@credits_posted"), rb_tb_unpack_u128(&item->credits_posted));
-        rb_ivar_set(obj, rb_intern("@timestamp"), ULL2NUM(item->timestamp));
+        rb_ivar_set(obj, rb_intern("@timestamp"), RB_ULL2NUM(item->timestamp));
         uint8_t zero[sizeof(item->reserved)] = {0};
         tb_assert(memcmp(item->reserved, zero, sizeof(item->reserved)) == 0);
         rb_ary_push(results, obj);
@@ -205,15 +205,15 @@ static void rb_tb_serialize_query_accounts(VALUE items_rb, uint8_t *buf, long co
         VALUE item_rb = RARRAY_AREF(items_rb, i);
         tb_query_filter_t *item = &items[i];
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->ledger = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
+        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->ledger = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
+        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
         memset(item->reserved, 0, sizeof(item->reserved));
-        item->timestamp_min = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
-        item->timestamp_max = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->timestamp_min = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
+        item->timestamp_max = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
+        item->limit = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
+        item->flags = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
     }
 }
 
@@ -232,13 +232,13 @@ static VALUE rb_tb_deserialize_query_accounts(const uint8_t *buf, uint32_t buf_s
         rb_ivar_set(obj, rb_intern("@credits_pending"), rb_tb_unpack_u128(&item->credits_pending));
         rb_ivar_set(obj, rb_intern("@credits_posted"), rb_tb_unpack_u128(&item->credits_posted));
         rb_ivar_set(obj, rb_intern("@user_data_128"), rb_tb_unpack_u128(&item->user_data_128));
-        rb_ivar_set(obj, rb_intern("@user_data_64"), ULL2NUM(item->user_data_64));
-        rb_ivar_set(obj, rb_intern("@user_data_32"), UINT2NUM(item->user_data_32));
+        rb_ivar_set(obj, rb_intern("@user_data_64"), RB_ULL2NUM(item->user_data_64));
+        rb_ivar_set(obj, rb_intern("@user_data_32"), RB_UINT2NUM(item->user_data_32));
         tb_assert(item->reserved == 0);
-        rb_ivar_set(obj, rb_intern("@ledger"), UINT2NUM(item->ledger));
-        rb_ivar_set(obj, rb_intern("@code"), UINT2NUM(item->code));
-        rb_ivar_set(obj, rb_intern("@flags"), UINT2NUM(item->flags));
-        rb_ivar_set(obj, rb_intern("@timestamp"), ULL2NUM(item->timestamp));
+        rb_ivar_set(obj, rb_intern("@ledger"), RB_UINT2NUM(item->ledger));
+        rb_ivar_set(obj, rb_intern("@code"), RB_UINT2NUM(item->code));
+        rb_ivar_set(obj, rb_intern("@flags"), RB_UINT2NUM(item->flags));
+        rb_ivar_set(obj, rb_intern("@timestamp"), RB_ULL2NUM(item->timestamp));
         rb_ary_push(results, obj);
     }
     return results;
@@ -250,15 +250,15 @@ static void rb_tb_serialize_query_transfers(VALUE items_rb, uint8_t *buf, long c
         VALUE item_rb = RARRAY_AREF(items_rb, i);
         tb_query_filter_t *item = &items[i];
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->ledger = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
+        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->ledger = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
+        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
         memset(item->reserved, 0, sizeof(item->reserved));
-        item->timestamp_min = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
-        item->timestamp_max = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->timestamp_min = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
+        item->timestamp_max = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
+        item->limit = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
+        item->flags = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
     }
 }
 
@@ -277,13 +277,13 @@ static VALUE rb_tb_deserialize_query_transfers(const uint8_t *buf, uint32_t buf_
         rb_ivar_set(obj, rb_intern("@amount"), rb_tb_unpack_u128(&item->amount));
         rb_ivar_set(obj, rb_intern("@pending_id"), rb_tb_unpack_u128(&item->pending_id));
         rb_ivar_set(obj, rb_intern("@user_data_128"), rb_tb_unpack_u128(&item->user_data_128));
-        rb_ivar_set(obj, rb_intern("@user_data_64"), ULL2NUM(item->user_data_64));
-        rb_ivar_set(obj, rb_intern("@user_data_32"), UINT2NUM(item->user_data_32));
-        rb_ivar_set(obj, rb_intern("@timeout"), UINT2NUM(item->timeout));
-        rb_ivar_set(obj, rb_intern("@ledger"), UINT2NUM(item->ledger));
-        rb_ivar_set(obj, rb_intern("@code"), UINT2NUM(item->code));
-        rb_ivar_set(obj, rb_intern("@flags"), UINT2NUM(item->flags));
-        rb_ivar_set(obj, rb_intern("@timestamp"), ULL2NUM(item->timestamp));
+        rb_ivar_set(obj, rb_intern("@user_data_64"), RB_ULL2NUM(item->user_data_64));
+        rb_ivar_set(obj, rb_intern("@user_data_32"), RB_UINT2NUM(item->user_data_32));
+        rb_ivar_set(obj, rb_intern("@timeout"), RB_UINT2NUM(item->timeout));
+        rb_ivar_set(obj, rb_intern("@ledger"), RB_UINT2NUM(item->ledger));
+        rb_ivar_set(obj, rb_intern("@code"), RB_UINT2NUM(item->code));
+        rb_ivar_set(obj, rb_intern("@flags"), RB_UINT2NUM(item->flags));
+        rb_ivar_set(obj, rb_intern("@timestamp"), RB_ULL2NUM(item->timestamp));
         rb_ary_push(results, obj);
     }
     return results;
@@ -300,13 +300,13 @@ static void rb_tb_serialize_create_accounts(VALUE items_rb, uint8_t *buf, long c
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@credits_pending")), &item->credits_pending);
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@credits_posted")), &item->credits_posted);
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
+        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
         item->reserved = 0;
-        item->ledger = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
-        item->flags = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@flags")));
-        item->timestamp = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp")));
+        item->ledger = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
+        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->flags = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->timestamp = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp")));
     }
 }
 
@@ -319,8 +319,8 @@ static VALUE rb_tb_deserialize_create_accounts(const uint8_t *buf, uint32_t buf_
     for (long i = 0; i < count; i++) {
         const tb_create_account_result_t *item = &items[i];
         VALUE obj = rb_obj_alloc(klass);
-        rb_ivar_set(obj, rb_intern("@timestamp"), ULL2NUM(item->timestamp));
-        rb_ivar_set(obj, rb_intern("@status"), UINT2NUM(item->status));
+        rb_ivar_set(obj, rb_intern("@timestamp"), RB_ULL2NUM(item->timestamp));
+        rb_ivar_set(obj, rb_intern("@status"), RB_UINT2NUM(item->status));
         tb_assert(item->reserved == 0);
         rb_ary_push(results, obj);
     }
@@ -338,13 +338,13 @@ static void rb_tb_serialize_create_transfers(VALUE items_rb, uint8_t *buf, long 
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@amount")), &item->amount);
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@pending_id")), &item->pending_id);
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->timeout = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@timeout")));
-        item->ledger = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
-        item->flags = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@flags")));
-        item->timestamp = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp")));
+        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
+        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->timeout = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@timeout")));
+        item->ledger = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
+        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->flags = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->timestamp = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp")));
     }
 }
 
@@ -357,8 +357,8 @@ static VALUE rb_tb_deserialize_create_transfers(const uint8_t *buf, uint32_t buf
     for (long i = 0; i < count; i++) {
         const tb_create_transfer_result_t *item = &items[i];
         VALUE obj = rb_obj_alloc(klass);
-        rb_ivar_set(obj, rb_intern("@timestamp"), ULL2NUM(item->timestamp));
-        rb_ivar_set(obj, rb_intern("@status"), UINT2NUM(item->status));
+        rb_ivar_set(obj, rb_intern("@timestamp"), RB_ULL2NUM(item->timestamp));
+        rb_ivar_set(obj, rb_intern("@status"), RB_UINT2NUM(item->status));
         tb_assert(item->reserved == 0);
         rb_ary_push(results, obj);
     }

--- a/src/clients/ruby/src/ext/tigerbeetle/rb_tb_gen.h
+++ b/src/clients/ruby/src/ext/tigerbeetle/rb_tb_gen.h
@@ -123,13 +123,13 @@ static void rb_tb_serialize_get_account_transfers(VALUE items_rb, uint8_t *buf, 
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@account_id")), &item->account_id);
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
         item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->code = (uint16_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
         memset(item->reserved, 0, sizeof(item->reserved));
         item->timestamp_min = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
         item->timestamp_max = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->limit = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
+        item->flags = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
     }
 }
 
@@ -168,13 +168,13 @@ static void rb_tb_serialize_get_account_balances(VALUE items_rb, uint8_t *buf, l
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@account_id")), &item->account_id);
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
         item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->code = (uint16_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
         memset(item->reserved, 0, sizeof(item->reserved));
         item->timestamp_min = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
         item->timestamp_max = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->limit = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
+        item->flags = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
     }
 }
 
@@ -206,14 +206,14 @@ static void rb_tb_serialize_query_accounts(VALUE items_rb, uint8_t *buf, long co
         tb_query_filter_t *item = &items[i];
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
         item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->ledger = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = (uint16_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->ledger = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
+        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
         memset(item->reserved, 0, sizeof(item->reserved));
         item->timestamp_min = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
         item->timestamp_max = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->limit = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
+        item->flags = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
     }
 }
 
@@ -251,14 +251,14 @@ static void rb_tb_serialize_query_transfers(VALUE items_rb, uint8_t *buf, long c
         tb_query_filter_t *item = &items[i];
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
         item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->ledger = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = (uint16_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->ledger = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
+        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
         memset(item->reserved, 0, sizeof(item->reserved));
         item->timestamp_min = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
         item->timestamp_max = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->limit = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
+        item->flags = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
     }
 }
 
@@ -301,11 +301,11 @@ static void rb_tb_serialize_create_accounts(VALUE items_rb, uint8_t *buf, long c
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@credits_posted")), &item->credits_posted);
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
         item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
         item->reserved = 0;
-        item->ledger = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = (uint16_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@code")));
-        item->flags = (uint16_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->ledger = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
+        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->flags = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@flags")));
         item->timestamp = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp")));
     }
 }
@@ -339,11 +339,11 @@ static void rb_tb_serialize_create_transfers(VALUE items_rb, uint8_t *buf, long 
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@pending_id")), &item->pending_id);
         rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
         item->user_data_64 = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->timeout = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@timeout")));
-        item->ledger = (uint32_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = (uint16_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@code")));
-        item->flags = (uint16_t)NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->user_data_32 = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        item->timeout = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@timeout")));
+        item->ledger = NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
+        item->code = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        item->flags = NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@flags")));
         item->timestamp = NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp")));
     }
 }

--- a/src/clients/ruby/src/ext/tigerbeetle/rb_tb_gen.h
+++ b/src/clients/ruby/src/ext/tigerbeetle/rb_tb_gen.h
@@ -14,7 +14,10 @@
 #include <string.h>
 
 static inline void rb_tb_pack_u128(VALUE v, void *dst) {
-    rb_integer_pack(v, dst, 16, 1, 0, INTEGER_PACK_LITTLE_ENDIAN);
+    int status = rb_integer_pack(v, dst, 16, 1, 0, INTEGER_PACK_LITTLE_ENDIAN);
+    if (status != 0 && status != 1) {
+        rb_raise(rb_eRangeError, "integer must be between 0 and 2**128 - 1");
+    }
 }
 
 static inline VALUE rb_tb_unpack_u128(const void *src) {

--- a/src/clients/ruby/src/ext/tigerbeetle/tigerbeetle.c
+++ b/src/clients/ruby/src/ext/tigerbeetle/tigerbeetle.c
@@ -101,7 +101,7 @@ static VALUE rb_tb_request_result(VALUE self) {
         }
     }
 
-    return rb_ary_new_from_args(2, UINT2NUM(req->status), result);
+    return rb_ary_new_from_args(2, RB_UINT2NUM(req->status), result);
 }
 
 static void rb_tb_write_completion(int fd, rb_tb_request_t *req) {
@@ -187,7 +187,7 @@ static VALUE rb_tb_client_initialize(
     const char *addr = StringValueCStr(addresses_rb);
     uint32_t addr_len = (uint32_t)RSTRING_LEN(addresses_rb);
 
-    int completion_fd = NUM2INT(completion_fd_rb);
+    int completion_fd = RB_NUM2INT(completion_fd_rb);
 
     TB_INIT_STATUS status = tb_client_init(
         client, cluster_id_bytes, addr, addr_len, (uintptr_t)completion_fd, rb_tb_on_completion
@@ -232,7 +232,7 @@ static VALUE rb_tb_client_submit(VALUE self, VALUE operation_rb, VALUE items_rb)
     tb_client_t *client;
     TypedData_Get_Struct(self, tb_client_t, &rb_tb_client_type, client);
 
-    TB_OPERATION operation = (TB_OPERATION)NUM2INT(operation_rb);
+    TB_OPERATION operation = (TB_OPERATION)RB_NUM2INT(operation_rb);
     long count = RARRAY_LEN(items_rb);
 
     rb_tb_request_t *req = malloc(sizeof(rb_tb_request_t));
@@ -290,12 +290,12 @@ static VALUE rb_tb_client_submit(VALUE self, VALUE operation_rb, VALUE items_rb)
 static VALUE rb_tb_request_id(VALUE self) {
     rb_tb_request_t *req;
     TypedData_Get_Struct(self, rb_tb_request_t, &rb_tb_request_type, req);
-    return ULL2NUM((unsigned long long)(uintptr_t)req);
+    return RB_ULL2NUM((unsigned long long)(uintptr_t)req);
 }
 
 static void rb_tb_init_native_client(VALUE mTigerBeetle) {
-    rb_define_const(mTigerBeetle, "PACKET_OK", INT2NUM(TB_PACKET_OK));
-    rb_define_const(mTigerBeetle, "PACKET_CLIENT_SHUTDOWN", INT2NUM(TB_PACKET_CLIENT_SHUTDOWN));
+    rb_define_const(mTigerBeetle, "PACKET_OK", RB_INT2NUM(TB_PACKET_OK));
+    rb_define_const(mTigerBeetle, "PACKET_CLIENT_SHUTDOWN", RB_INT2NUM(TB_PACKET_CLIENT_SHUTDOWN));
 
     VALUE cNativeClient = rb_define_class_under(mTigerBeetle, "NativeClient", rb_cObject);
     rb_define_alloc_func(cNativeClient, rb_tb_client_alloc);

--- a/src/clients/ruby/src/ext/tigerbeetle/tigerbeetle.c
+++ b/src/clients/ruby/src/ext/tigerbeetle/tigerbeetle.c
@@ -182,7 +182,7 @@ static VALUE rb_tb_client_initialize(
     TypedData_Get_Struct(self, tb_client_t, &rb_tb_client_type, client);
 
     uint8_t cluster_id_bytes[16] = {0};
-    rb_integer_pack(cluster_id_rb, cluster_id_bytes, 16, 1, 0, INTEGER_PACK_LITTLE_ENDIAN);
+    rb_tb_pack_u128(cluster_id_rb, cluster_id_bytes);
 
     const char *addr = StringValueCStr(addresses_rb);
     uint32_t addr_len = (uint32_t)RSTRING_LEN(addresses_rb);

--- a/src/clients/ruby/tests/integration/test_uint128_range.rb
+++ b/src/clients/ruby/tests/integration/test_uint128_range.rb
@@ -1,0 +1,51 @@
+require_relative "tiger_beetle_integration_test"
+
+class TestUInt128Range < TigerBeetleIntegrationTest
+  UINT128_MAX = (1 << 128) - 1
+  UINT128_OVERFLOW = 1 << 128
+  UINT128_TOO_BIG = 9_999_999_999_999_999_999_999_999_999_999_999_999_999
+  UINT128_RANGE_ERROR = "integer must be between 0 and 2**128 - 1"
+
+  def test_range_check_u128_accepts_max
+    assert_equal([], @client.lookup_accounts([UINT128_MAX]))
+  end
+
+  def test_range_check_u128_cannot_exceed
+    assert_u128_range_error do
+      @client.lookup_accounts([UINT128_OVERFLOW])
+    end
+  end
+
+  def test_range_check_u128_cannot_be_too_big
+    assert_u128_range_error do
+      @client.lookup_accounts([UINT128_TOO_BIG])
+    end
+  end
+
+  def test_range_check_u128_cannot_be_negative
+    assert_u128_range_error do
+      @client.lookup_accounts([-1])
+    end
+  end
+
+  def test_range_check_u128_struct_field_cannot_exceed
+    account = TigerBeetle::Account.new(id: UINT128_OVERFLOW, ledger: 1, code: 1)
+
+    assert_u128_range_error do
+      @client.create_accounts([account])
+    end
+  end
+
+  def test_range_check_u128_cluster_id_cannot_exceed
+    assert_u128_range_error do
+      TigerBeetle::Client.new(cluster_id: UINT128_OVERFLOW, replica_addresses: @tb_address)
+    end
+  end
+
+  private
+
+  def assert_u128_range_error(&block)
+    error = assert_raises(RangeError, &block)
+    assert_equal(UINT128_RANGE_ERROR, error.message)
+  end
+end


### PR DESCRIPTION
As discussed last Friday, this PR addresses potential `u128` overflow for Ruby, similar to #3762.

In the process, I also noticed two things:

1. I took a bit of a shortcut in `ruby_bindings.zig` when it came to handling flags and code. Instead of a wider conversion function and casts we're now using narrower conversion functions.
2. The used macro names like `NUM2UINT` etc., are soft-deprecated and `RB_` prefixed versions are preferred now. So I updated that too.