### PR TITLE
clients/ruby: Add `status_name`

### DIFF
--- a/src/clients/ruby/ruby_bindings.zig
+++ b/src/clients/ruby/ruby_bindings.zig
@@ -93,6 +93,12 @@ fn ruby_type_name(comptime Type: type) []const u8 {
     return type_basename(Type);
 }
 
+fn result_status_type(comptime Type: type) ?type {
+    if (Type == tb.CreateAccountResult) return tb.CreateAccountStatus;
+    if (Type == tb.CreateTransferResult) return tb.CreateTransferStatus;
+    return null;
+}
+
 fn operation_function_name(comptime operation: tb.Operation) []const u8 {
     return @tagName(operation);
 }
@@ -186,6 +192,12 @@ fn emit_struct_class(
             "    attr_{s} :{s}\n",
             .{ if (read_only) "reader" else "accessor", field.name },
         );
+        if (comptime read_only and
+            std.mem.eql(u8, field.name, "status") and
+            result_status_type(Type) != null)
+        {
+            buffer.print("    attr_reader :status_name\n", .{});
+        }
     }
     buffer.print("\n", .{});
 
@@ -212,6 +224,13 @@ fn emit_struct_class(
             buffer.print("      @{s} = 0\n", .{field.name});
         }
         buffer.print("    end\n", .{});
+
+        if (comptime result_status_type(Type) != null) {
+            buffer.print("\n", .{});
+            buffer.print("    def to_s =\n", .{});
+            buffer.write("      \"#<#{self.class} timestamp=#{@timestamp} ");
+            buffer.write("status_name=#{@status_name}>\"\n");
+        }
     }
     buffer.print("  end\n\n", .{});
 }
@@ -253,6 +272,23 @@ fn emit_rbs_constants_module(
     buffer.print("  end\n\n", .{});
 }
 
+fn emit_rbs_status_name_alias(
+    buffer: *Buffer,
+    comptime StatusType: type,
+    comptime alias_name: []const u8,
+) void {
+    assert(@typeInfo(StatusType) == .@"enum");
+
+    buffer.print("  type {s} =\n", .{alias_name});
+    comptime var sep: []const u8 = "    ";
+    inline for (@typeInfo(StatusType).@"enum".fields) |field| {
+        if (comptime std.mem.startsWith(u8, field.name, "deprecated_")) continue;
+        buffer.print("{s}:{s}\n", .{ sep, field.name });
+        sep = "    | ";
+    }
+    buffer.print("\n", .{});
+}
+
 fn emit_rbs_struct_class(
     buffer: *Buffer,
     comptime Type: type,
@@ -272,6 +308,13 @@ fn emit_rbs_struct_class(
             "    attr_{s} {s}: Integer\n",
             .{ if (read_only) "reader" else "accessor", field.name },
         );
+        if (comptime read_only and std.mem.eql(u8, field.name, "status")) {
+            if (comptime Type == tb.CreateAccountResult) {
+                buffer.print("    attr_reader status_name: create_account_status_name\n", .{});
+            } else if (comptime Type == tb.CreateTransferResult) {
+                buffer.print("    attr_reader status_name: create_transfer_status_name\n", .{});
+            }
+        }
     }
     buffer.print("\n", .{});
 
@@ -353,6 +396,16 @@ fn emit_rbs_bindings(buffer: *Buffer) void {
     emit_rbs_struct_class(buffer, tb.QueryFilter, "QueryFilter", false);
 
     emit_rbs_struct_class(buffer, tb.AccountBalance, "AccountBalance", true);
+    emit_rbs_status_name_alias(
+        buffer,
+        tb.CreateAccountStatus,
+        "create_account_status_name",
+    );
+    emit_rbs_status_name_alias(
+        buffer,
+        tb.CreateTransferStatus,
+        "create_transfer_status_name",
+    );
     emit_rbs_struct_class(buffer, tb.CreateAccountResult, "CreateAccountResult", true);
     emit_rbs_struct_class(buffer, tb.CreateTransferResult, "CreateTransferResult", true);
 
@@ -465,6 +518,31 @@ fn emit_c_init_error_message(buffer: *Buffer) void {
         \\
         \\
     );
+}
+
+fn emit_c_status_name_function(
+    buffer: *Buffer,
+    comptime StatusType: type,
+    comptime function_name: []const u8,
+) void {
+    assert(@typeInfo(StatusType) == .@"enum");
+
+    buffer.print("static VALUE {s}(uint32_t status) {{\n", .{function_name});
+    buffer.print("    switch (status) {{\n", .{});
+    inline for (@typeInfo(StatusType).@"enum".fields) |field| {
+        if (comptime std.mem.startsWith(u8, field.name, "deprecated_")) continue;
+        const value: u64 = @intCast(@intFromEnum(@field(StatusType, field.name)));
+        buffer.print("    case {d}:\n", .{value});
+        buffer.print("        return ID2SYM(rb_intern(\"{s}\"));\n", .{field.name});
+    }
+    buffer.write(
+        \\    default:
+        \\        tb_assert(false);
+        \\        return Qnil;
+        \\    }
+        \\}
+    );
+    buffer.write("\n\n");
 }
 
 fn emit_c_num_from_ruby(
@@ -584,6 +662,18 @@ fn emit_c_deserialize_struct(buffer: *Buffer, comptime operation: tb.Operation) 
         buffer.print("        rb_ivar_set(obj, rb_intern(\"@{s}\"), ", .{field.name});
         emit_c_value_from_field(buffer, field.type, field_expr);
         buffer.print(");\n", .{});
+        if (comptime std.mem.eql(u8, field.name, "status")) {
+            if (comptime result_status_type(Type) != null) {
+                buffer.print(
+                    \\        rb_ivar_set(
+                    \\            obj,
+                    \\            rb_intern("@status_name"),
+                    \\            rb_tb_{s}_status_name(item->status)
+                    \\        );
+                    \\
+                , .{operation_name});
+            }
+        }
     }
 
     buffer.print("        rb_ary_push(results, obj);\n", .{});
@@ -697,6 +787,16 @@ fn emit_c_header(buffer: *Buffer) void {
 
     emit_c_header_preamble(buffer);
     emit_c_init_error_message(buffer);
+    emit_c_status_name_function(
+        buffer,
+        tb.CreateAccountStatus,
+        "rb_tb_create_accounts_status_name",
+    );
+    emit_c_status_name_function(
+        buffer,
+        tb.CreateTransferStatus,
+        "rb_tb_create_transfers_status_name",
+    );
 
     inline for (@typeInfo(tb.Operation).@"enum".fields) |operation_field| {
         const operation: tb.Operation = @enumFromInt(operation_field.value);

--- a/src/clients/ruby/sig/tigerbeetle.rbs
+++ b/src/clients/ruby/sig/tigerbeetle.rbs
@@ -254,9 +254,109 @@ module TigerBeetle
     def initialize: () -> void
   end
 
+  type create_account_status_name =
+    :created
+    | :linked_event_failed
+    | :linked_event_chain_open
+    | :imported_event_expected
+    | :imported_event_not_expected
+    | :timestamp_must_be_zero
+    | :imported_event_timestamp_out_of_range
+    | :imported_event_timestamp_must_not_advance
+    | :reserved_field
+    | :reserved_flag
+    | :id_must_not_be_zero
+    | :id_must_not_be_int_max
+    | :exists_with_different_flags
+    | :exists_with_different_user_data_128
+    | :exists_with_different_user_data_64
+    | :exists_with_different_user_data_32
+    | :exists_with_different_ledger
+    | :exists_with_different_code
+    | :exists
+    | :flags_are_mutually_exclusive
+    | :debits_pending_must_be_zero
+    | :debits_posted_must_be_zero
+    | :credits_pending_must_be_zero
+    | :credits_posted_must_be_zero
+    | :ledger_must_not_be_zero
+    | :code_must_not_be_zero
+    | :imported_event_timestamp_must_not_regress
+
+  type create_transfer_status_name =
+    :created
+    | :linked_event_failed
+    | :linked_event_chain_open
+    | :imported_event_expected
+    | :imported_event_not_expected
+    | :timestamp_must_be_zero
+    | :imported_event_timestamp_out_of_range
+    | :imported_event_timestamp_must_not_advance
+    | :reserved_flag
+    | :id_must_not_be_zero
+    | :id_must_not_be_int_max
+    | :exists_with_different_flags
+    | :exists_with_different_pending_id
+    | :exists_with_different_timeout
+    | :exists_with_different_debit_account_id
+    | :exists_with_different_credit_account_id
+    | :exists_with_different_amount
+    | :exists_with_different_user_data_128
+    | :exists_with_different_user_data_64
+    | :exists_with_different_user_data_32
+    | :exists_with_different_ledger
+    | :exists_with_different_code
+    | :exists
+    | :id_already_failed
+    | :flags_are_mutually_exclusive
+    | :debit_account_id_must_not_be_zero
+    | :debit_account_id_must_not_be_int_max
+    | :credit_account_id_must_not_be_zero
+    | :credit_account_id_must_not_be_int_max
+    | :accounts_must_be_different
+    | :pending_id_must_be_zero
+    | :pending_id_must_not_be_zero
+    | :pending_id_must_not_be_int_max
+    | :pending_id_must_be_different
+    | :timeout_reserved_for_pending_transfer
+    | :closing_transfer_must_be_pending
+    | :ledger_must_not_be_zero
+    | :code_must_not_be_zero
+    | :debit_account_not_found
+    | :credit_account_not_found
+    | :accounts_must_have_the_same_ledger
+    | :transfer_must_have_the_same_ledger_as_accounts
+    | :pending_transfer_not_found
+    | :pending_transfer_not_pending
+    | :pending_transfer_has_different_debit_account_id
+    | :pending_transfer_has_different_credit_account_id
+    | :pending_transfer_has_different_ledger
+    | :pending_transfer_has_different_code
+    | :exceeds_pending_transfer_amount
+    | :pending_transfer_has_different_amount
+    | :pending_transfer_already_posted
+    | :pending_transfer_already_voided
+    | :pending_transfer_expired
+    | :imported_event_timestamp_must_not_regress
+    | :imported_event_timestamp_must_postdate_debit_account
+    | :imported_event_timestamp_must_postdate_credit_account
+    | :imported_event_timeout_must_be_zero
+    | :debit_account_already_closed
+    | :credit_account_already_closed
+    | :overflows_debits_pending
+    | :overflows_credits_pending
+    | :overflows_debits_posted
+    | :overflows_credits_posted
+    | :overflows_debits
+    | :overflows_credits
+    | :overflows_timeout
+    | :exceeds_credits
+    | :exceeds_debits
+
   class CreateAccountResult
     attr_reader timestamp: Integer
     attr_reader status: Integer
+    attr_reader status_name: create_account_status_name
 
     def initialize: () -> void
   end
@@ -264,6 +364,7 @@ module TigerBeetle
   class CreateTransferResult
     attr_reader timestamp: Integer
     attr_reader status: Integer
+    attr_reader status_name: create_transfer_status_name
 
     def initialize: () -> void
   end

--- a/src/clients/ruby/src/ext/tigerbeetle/rb_tb_gen.h
+++ b/src/clients/ruby/src/ext/tigerbeetle/rb_tb_gen.h
@@ -61,6 +61,212 @@ static const char *rb_tb_init_error_message(TB_INIT_STATUS status) {
     }
 }
 
+static VALUE rb_tb_create_accounts_status_name(uint32_t status) {
+    switch (status) {
+    case 4294967295:
+        return ID2SYM(rb_intern("created"));
+    case 1:
+        return ID2SYM(rb_intern("linked_event_failed"));
+    case 2:
+        return ID2SYM(rb_intern("linked_event_chain_open"));
+    case 22:
+        return ID2SYM(rb_intern("imported_event_expected"));
+    case 23:
+        return ID2SYM(rb_intern("imported_event_not_expected"));
+    case 3:
+        return ID2SYM(rb_intern("timestamp_must_be_zero"));
+    case 24:
+        return ID2SYM(rb_intern("imported_event_timestamp_out_of_range"));
+    case 25:
+        return ID2SYM(rb_intern("imported_event_timestamp_must_not_advance"));
+    case 4:
+        return ID2SYM(rb_intern("reserved_field"));
+    case 5:
+        return ID2SYM(rb_intern("reserved_flag"));
+    case 6:
+        return ID2SYM(rb_intern("id_must_not_be_zero"));
+    case 7:
+        return ID2SYM(rb_intern("id_must_not_be_int_max"));
+    case 15:
+        return ID2SYM(rb_intern("exists_with_different_flags"));
+    case 16:
+        return ID2SYM(rb_intern("exists_with_different_user_data_128"));
+    case 17:
+        return ID2SYM(rb_intern("exists_with_different_user_data_64"));
+    case 18:
+        return ID2SYM(rb_intern("exists_with_different_user_data_32"));
+    case 19:
+        return ID2SYM(rb_intern("exists_with_different_ledger"));
+    case 20:
+        return ID2SYM(rb_intern("exists_with_different_code"));
+    case 21:
+        return ID2SYM(rb_intern("exists"));
+    case 8:
+        return ID2SYM(rb_intern("flags_are_mutually_exclusive"));
+    case 9:
+        return ID2SYM(rb_intern("debits_pending_must_be_zero"));
+    case 10:
+        return ID2SYM(rb_intern("debits_posted_must_be_zero"));
+    case 11:
+        return ID2SYM(rb_intern("credits_pending_must_be_zero"));
+    case 12:
+        return ID2SYM(rb_intern("credits_posted_must_be_zero"));
+    case 13:
+        return ID2SYM(rb_intern("ledger_must_not_be_zero"));
+    case 14:
+        return ID2SYM(rb_intern("code_must_not_be_zero"));
+    case 26:
+        return ID2SYM(rb_intern("imported_event_timestamp_must_not_regress"));
+    default:
+        tb_assert(false);
+        return Qnil;
+    }
+}
+
+static VALUE rb_tb_create_transfers_status_name(uint32_t status) {
+    switch (status) {
+    case 4294967295:
+        return ID2SYM(rb_intern("created"));
+    case 1:
+        return ID2SYM(rb_intern("linked_event_failed"));
+    case 2:
+        return ID2SYM(rb_intern("linked_event_chain_open"));
+    case 56:
+        return ID2SYM(rb_intern("imported_event_expected"));
+    case 57:
+        return ID2SYM(rb_intern("imported_event_not_expected"));
+    case 3:
+        return ID2SYM(rb_intern("timestamp_must_be_zero"));
+    case 58:
+        return ID2SYM(rb_intern("imported_event_timestamp_out_of_range"));
+    case 59:
+        return ID2SYM(rb_intern("imported_event_timestamp_must_not_advance"));
+    case 4:
+        return ID2SYM(rb_intern("reserved_flag"));
+    case 5:
+        return ID2SYM(rb_intern("id_must_not_be_zero"));
+    case 6:
+        return ID2SYM(rb_intern("id_must_not_be_int_max"));
+    case 36:
+        return ID2SYM(rb_intern("exists_with_different_flags"));
+    case 40:
+        return ID2SYM(rb_intern("exists_with_different_pending_id"));
+    case 44:
+        return ID2SYM(rb_intern("exists_with_different_timeout"));
+    case 37:
+        return ID2SYM(rb_intern("exists_with_different_debit_account_id"));
+    case 38:
+        return ID2SYM(rb_intern("exists_with_different_credit_account_id"));
+    case 39:
+        return ID2SYM(rb_intern("exists_with_different_amount"));
+    case 41:
+        return ID2SYM(rb_intern("exists_with_different_user_data_128"));
+    case 42:
+        return ID2SYM(rb_intern("exists_with_different_user_data_64"));
+    case 43:
+        return ID2SYM(rb_intern("exists_with_different_user_data_32"));
+    case 67:
+        return ID2SYM(rb_intern("exists_with_different_ledger"));
+    case 45:
+        return ID2SYM(rb_intern("exists_with_different_code"));
+    case 46:
+        return ID2SYM(rb_intern("exists"));
+    case 68:
+        return ID2SYM(rb_intern("id_already_failed"));
+    case 7:
+        return ID2SYM(rb_intern("flags_are_mutually_exclusive"));
+    case 8:
+        return ID2SYM(rb_intern("debit_account_id_must_not_be_zero"));
+    case 9:
+        return ID2SYM(rb_intern("debit_account_id_must_not_be_int_max"));
+    case 10:
+        return ID2SYM(rb_intern("credit_account_id_must_not_be_zero"));
+    case 11:
+        return ID2SYM(rb_intern("credit_account_id_must_not_be_int_max"));
+    case 12:
+        return ID2SYM(rb_intern("accounts_must_be_different"));
+    case 13:
+        return ID2SYM(rb_intern("pending_id_must_be_zero"));
+    case 14:
+        return ID2SYM(rb_intern("pending_id_must_not_be_zero"));
+    case 15:
+        return ID2SYM(rb_intern("pending_id_must_not_be_int_max"));
+    case 16:
+        return ID2SYM(rb_intern("pending_id_must_be_different"));
+    case 17:
+        return ID2SYM(rb_intern("timeout_reserved_for_pending_transfer"));
+    case 64:
+        return ID2SYM(rb_intern("closing_transfer_must_be_pending"));
+    case 19:
+        return ID2SYM(rb_intern("ledger_must_not_be_zero"));
+    case 20:
+        return ID2SYM(rb_intern("code_must_not_be_zero"));
+    case 21:
+        return ID2SYM(rb_intern("debit_account_not_found"));
+    case 22:
+        return ID2SYM(rb_intern("credit_account_not_found"));
+    case 23:
+        return ID2SYM(rb_intern("accounts_must_have_the_same_ledger"));
+    case 24:
+        return ID2SYM(rb_intern("transfer_must_have_the_same_ledger_as_accounts"));
+    case 25:
+        return ID2SYM(rb_intern("pending_transfer_not_found"));
+    case 26:
+        return ID2SYM(rb_intern("pending_transfer_not_pending"));
+    case 27:
+        return ID2SYM(rb_intern("pending_transfer_has_different_debit_account_id"));
+    case 28:
+        return ID2SYM(rb_intern("pending_transfer_has_different_credit_account_id"));
+    case 29:
+        return ID2SYM(rb_intern("pending_transfer_has_different_ledger"));
+    case 30:
+        return ID2SYM(rb_intern("pending_transfer_has_different_code"));
+    case 31:
+        return ID2SYM(rb_intern("exceeds_pending_transfer_amount"));
+    case 32:
+        return ID2SYM(rb_intern("pending_transfer_has_different_amount"));
+    case 33:
+        return ID2SYM(rb_intern("pending_transfer_already_posted"));
+    case 34:
+        return ID2SYM(rb_intern("pending_transfer_already_voided"));
+    case 35:
+        return ID2SYM(rb_intern("pending_transfer_expired"));
+    case 60:
+        return ID2SYM(rb_intern("imported_event_timestamp_must_not_regress"));
+    case 61:
+        return ID2SYM(rb_intern("imported_event_timestamp_must_postdate_debit_account"));
+    case 62:
+        return ID2SYM(rb_intern("imported_event_timestamp_must_postdate_credit_account"));
+    case 63:
+        return ID2SYM(rb_intern("imported_event_timeout_must_be_zero"));
+    case 65:
+        return ID2SYM(rb_intern("debit_account_already_closed"));
+    case 66:
+        return ID2SYM(rb_intern("credit_account_already_closed"));
+    case 47:
+        return ID2SYM(rb_intern("overflows_debits_pending"));
+    case 48:
+        return ID2SYM(rb_intern("overflows_credits_pending"));
+    case 49:
+        return ID2SYM(rb_intern("overflows_debits_posted"));
+    case 50:
+        return ID2SYM(rb_intern("overflows_credits_posted"));
+    case 51:
+        return ID2SYM(rb_intern("overflows_debits"));
+    case 52:
+        return ID2SYM(rb_intern("overflows_credits"));
+    case 53:
+        return ID2SYM(rb_intern("overflows_timeout"));
+    case 54:
+        return ID2SYM(rb_intern("exceeds_credits"));
+    case 55:
+        return ID2SYM(rb_intern("exceeds_debits"));
+    default:
+        tb_assert(false);
+        return Qnil;
+    }
+}
+
 static VALUE rb_tb_deserialize_lookup_accounts(const uint8_t *buf, uint32_t buf_size) {
     VALUE klass = rb_path2class("TigerBeetle::Account");
     tb_assert(buf_size % sizeof(tb_account_t) == 0);
@@ -321,6 +527,11 @@ static VALUE rb_tb_deserialize_create_accounts(const uint8_t *buf, uint32_t buf_
         VALUE obj = rb_obj_alloc(klass);
         rb_ivar_set(obj, rb_intern("@timestamp"), RB_ULL2NUM(item->timestamp));
         rb_ivar_set(obj, rb_intern("@status"), RB_UINT2NUM(item->status));
+        rb_ivar_set(
+            obj,
+            rb_intern("@status_name"),
+            rb_tb_create_accounts_status_name(item->status)
+        );
         tb_assert(item->reserved == 0);
         rb_ary_push(results, obj);
     }
@@ -359,6 +570,11 @@ static VALUE rb_tb_deserialize_create_transfers(const uint8_t *buf, uint32_t buf
         VALUE obj = rb_obj_alloc(klass);
         rb_ivar_set(obj, rb_intern("@timestamp"), RB_ULL2NUM(item->timestamp));
         rb_ivar_set(obj, rb_intern("@status"), RB_UINT2NUM(item->status));
+        rb_ivar_set(
+            obj,
+            rb_intern("@status_name"),
+            rb_tb_create_transfers_status_name(item->status)
+        );
         tb_assert(item->reserved == 0);
         rb_ary_push(results, obj);
     }

--- a/src/clients/ruby/src/tigerbeetle/bindings.rb
+++ b/src/clients/ruby/src/tigerbeetle/bindings.rb
@@ -327,21 +327,29 @@ module TigerBeetle
   class CreateAccountResult
     attr_reader :timestamp
     attr_reader :status
+    attr_reader :status_name
 
     def initialize
       @timestamp = 0
       @status = 0
     end
+
+    def to_s =
+      "#<#{self.class} timestamp=#{@timestamp} status_name=#{@status_name}>"
   end
 
   class CreateTransferResult
     attr_reader :timestamp
     attr_reader :status
+    attr_reader :status_name
 
     def initialize
       @timestamp = 0
       @status = 0
     end
+
+    def to_s =
+      "#<#{self.class} timestamp=#{@timestamp} status_name=#{@status_name}>"
   end
 
 end

--- a/src/clients/ruby/tests/integration/test_account.rb
+++ b/src/clients/ruby/tests/integration/test_account.rb
@@ -8,6 +8,11 @@ class TestAccounts < TigerBeetleIntegrationTest
     assert_equal(1, results.length)
     assert_operator(results[0].timestamp, :>, 0)
     assert_equal(TigerBeetle::CreateAccountStatus::CREATED, results[0].status)
+    assert_equal(:created, results[0].status_name)
+    assert_equal(
+      "#<TigerBeetle::CreateAccountResult timestamp=#{results[0].timestamp} status_name=created>",
+      results[0].to_s
+    )
   end
 
   def test_create_account_duplicate
@@ -18,6 +23,7 @@ class TestAccounts < TigerBeetleIntegrationTest
     results = @client.create_accounts([account])
     assert_equal(1, results.length)
     assert_equal(TigerBeetle::CreateAccountStatus::EXISTS, results[0].status)
+    assert_equal(:exists, results[0].status_name)
   end
 
   def test_create_account_id_zero
@@ -26,6 +32,7 @@ class TestAccounts < TigerBeetleIntegrationTest
     results = @client.create_accounts([account])
     assert_equal(1, results.length)
     assert_equal(TigerBeetle::CreateAccountStatus::ID_MUST_NOT_BE_ZERO, results[0].status)
+    assert_equal(:id_must_not_be_zero, results[0].status_name)
   end
 
   def test_create_account_ledger_zero

--- a/src/clients/ruby/tests/integration/test_transfer.rb
+++ b/src/clients/ruby/tests/integration/test_transfer.rb
@@ -30,6 +30,7 @@ class TestTransfers < TigerBeetleIntegrationTest
     assert_equal(1, results.length)
     assert_operator(results[0].timestamp, :>, 0)
     assert_equal(TigerBeetle::CreateTransferStatus::CREATED, results[0].status)
+    assert_equal(:created, results[0].status_name)
   end
 
   def test_create_transfer_duplicate
@@ -47,6 +48,7 @@ class TestTransfers < TigerBeetleIntegrationTest
     results = @client.create_transfers([transfer])
     assert_equal(1, results.length)
     assert_equal(TigerBeetle::CreateTransferStatus::EXISTS, results[0].status)
+    assert_equal(:exists, results[0].status_name)
   end
 
   def test_create_transfer_id_zero
@@ -84,6 +86,7 @@ class TestTransfers < TigerBeetleIntegrationTest
       TigerBeetle::CreateTransferStatus::DEBIT_ACCOUNT_ID_MUST_NOT_BE_ZERO,
       results[0].status
     )
+    assert_equal(:debit_account_id_must_not_be_zero, results[0].status_name)
   end
 
   def test_create_transfer_credit_account_id_zero


### PR DESCRIPTION
@matklad Based on our discussion yesterday I did two things:

1. Add a new `status_name` attribute that returns the status as a Ruby symbol. `status` still contains the integer to match the wire format. [1]
2. Add a simple `to_s` method to `CreateAccountResult` and `CreateTransferResult` that shows them like this:
    ```
    #<TigerBeetle::CreateAccountResult timestamp=123... status_name=created>
    ```

This was an entirely mechanical change via the generator, and it improves the user experience a bit.

[1] If we ever feel like a breaking change, I think having the symbol as `status` and the actual integer value as `status_code` would feel slightly more idiomatic, but it's also not a big deal leaving it like this.