### PR TITLE
docs(go): fix Uint128 pkg.go.dev link

### DIFF
--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -135,7 +135,7 @@ account balances have a few helper functions to make it easier
 to convert 128-bit little-endian unsigned integers between
 `string`, `math/big.Int`, and `[]byte`.
 
-See the type [Uint128](https://pkg.go.dev/github.com/tigerbeetle/tigerbeetle-go/pkg/types#Uint128) for more details.
+See the type [Uint128](https://pkg.go.dev/github.com/tigerbeetle/tigerbeetle-go#Uint128) for more details.
 
 ### Account Flags
 

--- a/src/clients/go/docs.zig
+++ b/src/clients/go/docs.zig
@@ -49,7 +49,7 @@ pub const GoDocs = Docs{
     \\to convert 128-bit little-endian unsigned integers between
     \\`string`, `math/big.Int`, and `[]byte`.
     \\
-    \\See the type [Uint128](https://pkg.go.dev/github.com/tigerbeetle/tigerbeetle-go/pkg/types#Uint128) for more details.
+    \\See the type [Uint128](https://pkg.go.dev/github.com/tigerbeetle/tigerbeetle-go#Uint128) for more details.
     ,
 
     .account_flags_documentation =


### PR DESCRIPTION
## Why
The Go client README (and its `docs.zig` generator source) linked `Uint128` at:

`pkg.go.dev/.../tigerbeetle-go/pkg/types#Uint128`

That path is stale — `Uint128` is defined on the **module root** (`uint128.go`).

## Change
- `src/clients/go/docs.zig` — generator string
- `src/clients/go/README.md` — checked-in docs so GitHub is correct before the next regen

## Test plan
- [x] `rg pkg/types src/clients/go` → clean
- [x] Link points at `https://pkg.go.dev/github.com/tigerbeetle/tigerbeetle-go#Uint128`

AI-assisted; human-reviewed.
