### PR TITLE
docs(changelog): fix broken Codeberg and talks links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Released: 2026-07-03
 
 - [#3817](https://github.com/tigerbeetle/tigerbeetle/pull/3817)
 
-  Workaround MacOS builds on Zig 0.14.1 (see [issue](ttps://codeberg.org/ziglang/zig/issues/31658)).
+  Workaround MacOS builds on Zig 0.14.1 (see [issue](https://codeberg.org/ziglang/zig/issues/31658)).
 
 ### TigerTracks 🎧
 
@@ -3174,7 +3174,7 @@ this crash loop, please reach out to us on the Community Slack so we can help yo
 ### Internals
 - [#2713](https://github.com/tigerbeetle/tigerbeetle/pull/2713)
 
-  Add [talks](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TALKS.md) from
+  Add [talks](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/internals/talks.md) from
   SystemsDistributed '23, P99 CONF '23, Money2020 '24, and SYCL '24.
 
 - [#2710](https://github.com/tigerbeetle/tigerbeetle/pull/2710)


### PR DESCRIPTION
## Summary

Two **broken hrefs** in `CHANGELOG.md` (not prose/typo thrash):

1. Zig workaround entry used `ttps://codeberg.org/...` (missing `h`) → `https://codeberg.org/ziglang/zig/issues/31658`
2. Talks bulletin linked deleted `docs/TALKS.md` → current `docs/internals/talks.md`

## Why

Clickable changelog links should resolve. The talks file moved under `docs/internals/` ages ago; the Codeberg URL never had a valid scheme.

## Verification

- [x] `](ttps://` absent from CHANGELOG
- [x] `docs/TALKS.md` absent; `docs/internals/talks.md` present on disk
- Diff is two URL targets only

AI-assisted; human-reviewed.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
