### PR TITLE
docs(rust): align quickstart Cargo edition with samples

### DIFF
--- a/src/clients/rust/README.md
+++ b/src/clients/rust/README.md
@@ -22,7 +22,7 @@ Then create `Cargo.toml` and copy this into it:
 [package]
 name = "tigerbeetle-test"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 tigerbeetle.path = "../.."

--- a/src/clients/rust/docs.zig
+++ b/src/clients/rust/docs.zig
@@ -26,7 +26,7 @@ pub const RustDocs = Docs{
     \\[package]
     \\name = "tigerbeetle-test"
     \\version = "0.1.0"
-    \\edition = "2024"
+    \\edition = "2021"
     \\
     \\[dependencies]
     \\tigerbeetle.path = "../.."


### PR DESCRIPTION
## Summary

Rust client quickstart told people to paste `edition = "2024"` into a fresh `Cargo.toml`, but:

- `src/clients/rust/Cargo.toml` uses **2021**
- every sample under `samples/*/Cargo.toml` uses **2021**
- only the generator (`docs.zig`) and checked-in README advertised 2024

## Change

- `src/clients/rust/docs.zig` — generator project_file block → `edition = "2021"`
- `src/clients/rust/README.md` — matching one-line fix so GitHub is correct before the next regen

## Verification

- [x] no `edition = "2024"` left in docs.zig / README
- [x] samples already on 2021 (unchanged)

Copy-paste setup now matches the real crate. AI-assisted; human-reviewed.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
