### PR TITLE
docs: note linux.tigerbeetle.com is x86_64 for aarch64 operators

### DIFF
--- a/docs/operating/deploying/README.md
+++ b/docs/operating/deploying/README.md
@@ -8,7 +8,10 @@ deployment procedure is simple:
 - Format the data files, specifying cluster id, replica count, and replica index.
 - Start replicas, specifying path to the data file and addresses of all replicas in the cluster.
 
-Here's how to deploy a three replica cluster running on a single machine:
+Here's how to deploy a three replica cluster running on a single machine.
+
+The `linux.tigerbeetle.com` shortcut is **x86_64**; on **aarch64** Linux see
+[Installing](../installing.md#latest-release).
 
 ```console
 curl -Lo tigerbeetle.zip https://linux.tigerbeetle.com && unzip tigerbeetle.zip && ./tigerbeetle version

--- a/docs/operating/installing.md
+++ b/docs/operating/installing.md
@@ -9,6 +9,11 @@
 curl -Lo tigerbeetle.zip https://linux.tigerbeetle.com && unzip tigerbeetle.zip
 ./tigerbeetle version
 ```
+
+`https://linux.tigerbeetle.com` serves the **x86_64** Linux build. On **aarch64** Linux,
+download [`tigerbeetle-aarch64-linux.zip`] from the [Latest Release](#latest-release) table
+instead (or the matching asset on the GitHub releases page).
+
 </details>
 
 <details>

--- a/docs/start.md
+++ b/docs/start.md
@@ -19,6 +19,10 @@ You can download a pre-built binary from `tigerbeetle.com`:
 curl -Lo tigerbeetle.zip https://linux.tigerbeetle.com && unzip tigerbeetle.zip
 ./tigerbeetle version
 ```
+
+On **aarch64** Linux, the `linux.tigerbeetle.com` URL is x86_64-only — use the aarch64 zip from
+[Installing](./operating/installing.md#latest-release) instead.
+
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
Clarify that the Linux quick-install CDN URL (`https://linux.tigerbeetle.com`) serves **x86_64**, and point **aarch64** Linux users at the existing Latest Release table / `tigerbeetle-aarch64-linux.zip`.

Touches the same one-liner in:
- `docs/operating/installing.md`
- `docs/start.md`
- `docs/operating/deploying/README.md` (single-machine demo)

## Motivation
Fixes the discoverability gap in #2512: install docs already list aarch64 release zips further down, but the open `<details>` Linux curl path looks architecture-agnostic.

## Verification
- [x] Reference-style link `tigerbeetle-aarch64-linux.zip` already defined in installing.md
- [x] Docs-only; no binary/CDN behavior change
- [x] Skimmed for accidental relative-link breakage

Closes #2512

AI-assisted; human-reviewed.
