### PR TITLE
docs(node): fix AccountFlags.credits_must_not_exceed_debits name

### DIFF
--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -128,7 +128,7 @@ bitwise-or:
 
 * `AccountFlags.linked`
 * `AccountFlags.debits_must_not_exceed_credits`
-* `AccountFlags.credits_must_not_exceed_credits`
+* `AccountFlags.credits_must_not_exceed_debits`
 * `AccountFlags.history`
 
 

--- a/src/clients/node/docs.zig
+++ b/src/clients/node/docs.zig
@@ -43,7 +43,7 @@ pub const NodeDocs = Docs{
     \\
     \\* `AccountFlags.linked`
     \\* `AccountFlags.debits_must_not_exceed_credits`
-    \\* `AccountFlags.credits_must_not_exceed_credits`
+    \\* `AccountFlags.credits_must_not_exceed_debits`
     \\* `AccountFlags.history`
     \\
     ,


### PR DESCRIPTION
## Summary

- Node client docs advertised `AccountFlags.credits_must_not_exceed_credits`, which does not exist on the bindings.
- Correct flag is `AccountFlags.credits_must_not_exceed_debits` (mirror of `debits_must_not_exceed_credits`).

## Motivation

Copy/paste from the Node README would reference a missing enum member. Core (`src/tigerbeetle.zig`), Node bindings (`src/clients/node/src/bindings.ts`), and the account reference page all use `credits_must_not_exceed_debits`.

Fixed in both the generator (`docs.zig`) and the checked-in `README.md` so GitHub stays accurate before any regen.

## Verification

- `rg credits_must_not_exceed_credits src/clients/node/docs.zig src/clients/node/README.md` → empty
- Cross-checked against `bindings.ts` + `src/tigerbeetle.zig` flag definitions
- Diff: 2 files, +2/-2 (single token each)

## Notes

- AI-assisted; human-reviewed. DCO signed.
- Orthogonal to open packaging coalesce / Go / Rust Bartok9 queue.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
