### PR TITLE
docs(python): fix AccountFlags.credits_must_not_exceed_debits name

### DIFF
--- a/src/clients/python/README.md
+++ b/src/clients/python/README.md
@@ -127,7 +127,7 @@ To toggle behavior for an account, combine enum values stored in the
 
 * `AccountFlags.linked`
 * `AccountFlags.debits_must_not_exceed_credits`
-* `AccountFlags.credits_must_not_exceed_credits`
+* `AccountFlags.credits_must_not_exceed_debits`
 * `AccountFlags.history`
 
 

--- a/src/clients/python/docs.zig
+++ b/src/clients/python/docs.zig
@@ -34,7 +34,7 @@ pub const PythonDocs = Docs{
     \\
     \\* `AccountFlags.linked`
     \\* `AccountFlags.debits_must_not_exceed_credits`
-    \\* `AccountFlags.credits_must_not_exceed_credits`
+    \\* `AccountFlags.credits_must_not_exceed_debits`
     \\* `AccountFlags.history`
     \\
     ,


### PR DESCRIPTION
## Summary

- Python client docs advertised `AccountFlags.credits_must_not_exceed_credits`, which is not a real flag.
- Correct name is `AccountFlags.credits_must_not_exceed_debits`.

## Motivation

Same doc generator slip as the Node client guide: the bullet list under Account Flags repeated `…_exceed_credits` on both constraints. Users reading the Python README would try an identifier that bindings do not export.

Core and `bindings.py` define `credits_must_not_exceed_debits`. Updated `docs.zig` (source of generated READMEs) and the checked-in `README.md`.

## Verification

- Wrong token gone from python `docs.zig` + `README.md`
- Confirmed real flag name in Python bindings / core account flags
- Minimal diff: 2 files, one token each

## Notes

- AI-assisted; human-reviewed. DCO signed.
- Node twin is a separate PR so each client can land independently.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
