### PR TITLE
docs(java): fix AccountFlags.CREDITS_MUST_NOT_EXCEED_DEBITS name

### DIFF
--- a/src/clients/java/README.md
+++ b/src/clients/java/README.md
@@ -188,7 +188,7 @@ To toggle behavior for an account, combine enum values stored in the
 
 * `AccountFlags.LINKED`
 * `AccountFlags.DEBITS_MUST_NOT_EXCEED_CREDITS`
-* `AccountFlags.CREDITS_MUST_NOT_EXCEED_CREDITS`
+* `AccountFlags.CREDITS_MUST_NOT_EXCEED_DEBITS`
 * `AccountFlags.HISTORY`
 
 For example, to link two accounts where the first account

--- a/src/clients/java/docs.zig
+++ b/src/clients/java/docs.zig
@@ -103,7 +103,7 @@ pub const JavaDocs = Docs{
     \\
     \\* `AccountFlags.LINKED`
     \\* `AccountFlags.DEBITS_MUST_NOT_EXCEED_CREDITS`
-    \\* `AccountFlags.CREDITS_MUST_NOT_EXCEED_CREDITS`
+    \\* `AccountFlags.CREDITS_MUST_NOT_EXCEED_DEBITS`
     \\* `AccountFlags.HISTORY`
     ,
 


### PR DESCRIPTION
## Summary

Java client docs advertised a non-existent flag:

`AccountFlags.CREDITS_MUST_NOT_EXCEED_CREDITS`

The real constant (bindings + core) is:

`AccountFlags.CREDITS_MUST_NOT_EXCEED_DEBITS`

## Motivation

Same generator slip as the Node (#3893) and Python (#3894) copies: the “must not exceed” pair repeated `…CREDITS` on both bullets. Copy-paste from the Java README would fail to compile / not resolve.

Fixed at the generator source and the checked-in README:

- `src/clients/java/docs.zig`
- `src/clients/java/README.md`

## Verification

- `rg CREDITS_MUST_NOT_EXCEED_CREDITS src/clients/java/docs.zig src/clients/java/README.md` → empty
- Confirmed `AccountFlags.CREDITS_MUST_NOT_EXCEED_DEBITS` in `AccountFlags.java`

AI-assisted; human-reviewed. Typo freeze exempt: wrong API identifier, not prose nit.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h