### PR TITLE
io/storage: add the ability to do per io dsync, and explicit fsync

### DIFF
--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -1108,11 +1108,10 @@ pub const IO = struct {
     /// instead.
     /// https://twitter.com/TigerBeetleDB/status/1422491736224436225
     fn fs_sync(fd: fd_t) !void {
-        _ = fd; // autofix
         // TODO: This is of dubious safety - it's _not_ safe to fall back on posix.fsync unless it's
         // known at startup that the disk (eg, an external disk on a Mac) doesn't support
         // F_FULLFSYNC.
-        // _ = posix.fcntl(fd, posix.F.FULLFSYNC, 1) catch return posix.fsync(fd);
+        _ = posix.fcntl(fd, posix.F.FULLFSYNC, 1) catch return posix.fsync(fd);
     }
 
     /// Allocates a file contiguously using fallocate() if supported.

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -18,6 +18,8 @@ pub const IO = struct {
     pub const Stats = common.Stats;
     pub const NextTickSource = common.NextTickSource;
 
+    pub const dsync_all = false;
+
     kq: fd_t,
     event_id: Event = 0,
     time: TimeOS = .{},
@@ -261,6 +263,7 @@ pub const IO = struct {
             buf: [*]const u8,
             len: u32,
             offset: u64,
+            dsync: bool,
         },
         next_tick: struct {
             source: NextTickSource,
@@ -809,6 +812,7 @@ pub const IO = struct {
         fd: fd_t,
         buffer: []const u8,
         offset: u64,
+        options: struct { dsync: bool },
     ) void {
         self.submit(
             context,
@@ -820,6 +824,7 @@ pub const IO = struct {
                 .buf = buffer.ptr,
                 .len = @as(u32, @intCast(buffer_limit(buffer.len))),
                 .offset = offset,
+                .dsync = options.dsync,
             },
             struct {
                 fn do_operation(op: anytype) WriteError!usize {
@@ -827,7 +832,9 @@ pub const IO = struct {
                     // below) is _synchronous_, so it's safe to call fs_sync after it has
                     // completed.
                     const result = posix.pwrite(op.fd, op.buf[0..op.len], op.offset);
-                    try fs_sync(op.fd);
+                    if (op.dsync) {
+                        try fs_sync(op.fd);
+                    }
 
                     return result;
                 }
@@ -1014,7 +1021,15 @@ pub const IO = struct {
         var flags: posix.O = .{
             .CLOEXEC = true,
             .ACCMODE = if (purpose == .inspect) .RDONLY else .RDWR,
-            .DSYNC = true,
+
+            // Even though DSYNC false is the default, spell it out here explicitly. Non-grid writes
+            // are flushed immediately after writing with fs_sync. Grid writes aren't, and are
+            // flushed before returning from compaction after each beat.
+            //
+            // In any case, DSYNC is broken on Darwin:
+            // https://x.com/TigerBeetleDB/status/1536628729031581697
+            // To work around this, fs_sync() is explicitly called after writing in do_operation.
+            .DSYNC = false,
         };
         var mode: posix.mode_t = 0;
 
@@ -1033,8 +1048,8 @@ pub const IO = struct {
             },
         }
 
-        // This is critical as we rely on O_DSYNC for fsync() whenever we write to the file:
-        assert(flags.DSYNC);
+        // Potentially surprising: see the explanation in `var flags`.
+        assert(!flags.DSYNC and !dsync_all);
 
         // Be careful with openat(2): "If pathname is absolute, then dirfd is ignored." (man page)
         assert(!std.fs.path.isAbsolute(relative_path));

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -1108,10 +1108,11 @@ pub const IO = struct {
     /// instead.
     /// https://twitter.com/TigerBeetleDB/status/1422491736224436225
     fn fs_sync(fd: fd_t) !void {
+        _ = fd; // autofix
         // TODO: This is of dubious safety - it's _not_ safe to fall back on posix.fsync unless it's
         // known at startup that the disk (eg, an external disk on a Mac) doesn't support
         // F_FULLFSYNC.
-        _ = posix.fcntl(fd, posix.F.FULLFSYNC, 1) catch return posix.fsync(fd);
+        // _ = posix.fcntl(fd, posix.F.FULLFSYNC, 1) catch return posix.fsync(fd);
     }
 
     /// Allocates a file contiguously using fallocate() if supported.

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -23,6 +23,8 @@ pub const IO = struct {
     pub const Stats = common.Stats;
     pub const NextTickSource = common.NextTickSource;
 
+    pub const dsync_all = true;
+
     ring: IO_Uring,
 
     /// Completions and deferred callbacks that are ready to have their callbacks run.
@@ -1257,7 +1259,11 @@ pub const IO = struct {
         fd: fd_t,
         buffer: []const u8,
         offset: u64,
+        options: struct { dsync: bool },
     ) void {
+        // Linux dsync is efficient - it's used on every write.
+        _ = options;
+
         completion.* = .{
             .io = self,
             .context = context,
@@ -1537,7 +1543,7 @@ pub const IO = struct {
         }
 
         // This is critical as we rely on O_DSYNC for fsync() whenever we write to the file:
-        assert(flags.DSYNC);
+        assert(flags.DSYNC and dsync_all);
 
         const fd = try posix.openat(dir_fd, relative_path, flags, mode);
         // TODO Return a proper error message when the path exists or does not exist (init/start).

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -95,6 +95,7 @@ test "open/write/read/close/statx" {
                 self.fd.?,
                 &self.write_buf,
                 10,
+                .{ .dsync = true },
             );
         }
 

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -18,6 +18,8 @@ pub const IO = struct {
     pub const Stats = common.Stats;
     pub const NextTickSource = common.NextTickSource;
 
+    pub const dsync_all = true;
+
     iocp: os.windows.HANDLE,
     time: TimeOS = .{},
     io_pending: usize = 0,
@@ -954,7 +956,11 @@ pub const IO = struct {
         fd: fd_t,
         buffer: []const u8,
         offset: u64,
+        options: struct { dsync: bool },
     ) void {
+        // Windows dsync is efficient - it's used on every write.
+        _ = options;
+
         self.submit(
             context,
             callback,
@@ -1277,7 +1283,7 @@ pub const IO = struct {
         attributes |= os.windows.FILE_WRITE_THROUGH;
 
         // This is critical as we rely on O_DSYNC for fsync() whenever we write to the file:
-        assert((attributes & os.windows.FILE_WRITE_THROUGH) > 0);
+        assert((attributes & os.windows.FILE_WRITE_THROUGH) > 0 and dsync_all);
 
         // It's a little confusing, but with NtCreateFile, which is what windows_open_file uses
         // under the hood, not specifying anything gets you a file capable of overlapped IO.

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -249,6 +249,7 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         resource_pool: ResourcePool,
 
         scan_buffer_pool: ScanBufferPool,
+        flush: Grid.Flush = undefined,
 
         radix_buffer: ScratchMemory,
 
@@ -762,6 +763,33 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
                         tree.manifest.assert_level_table_counts();
                     }
                 }
+            }
+
+            // On the last beat, wait until everything has been persisted before calling the
+            // callback.
+            if (last_beat) {
+                forest.grid.superblock.storage.flush_sectors(flush_callback, &forest.flush);
+            } else {
+                forest.compact_finish_dispatch_callback();
+            }
+        }
+
+        pub fn flush_callback(flush: *Grid.Flush) void {
+            const forest: *Forest = @alignCast(@fieldParentPtr("flush", flush));
+            forest.compact_finish_dispatch_callback();
+        }
+
+        pub fn compact_finish_dispatch_callback(forest: *Forest) void {
+            assert(forest.progress.? == .compact);
+            assert(forest.progress.?.compact.trees_done);
+            assert(forest.progress.?.compact.manifest_log_done);
+
+            const op = forest.progress.?.compact.op;
+            const compaction_beat = op % constants.lsm_compaction_ops;
+            const last_beat = compaction_beat == constants.lsm_compaction_ops - 1;
+
+            if (last_beat) {
+                assert(forest.grid.superblock.storage.unflushed == 0);
             }
 
             const callback = forest.progress.?.compact.callback;

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -100,6 +100,7 @@ pub fn StorageType(comptime IO: type) type {
         dir_fd: IO.fd_t,
         fd: IO.fd_t,
         unflushed: u64 = 0,
+        purpose: IO.OpenDataFilePurpose,
 
         pub fn init(io: *IO, tracer: *Tracer, options: struct {
             path: []const u8,
@@ -129,12 +130,14 @@ pub fn StorageType(comptime IO: type) type {
                 .tracer = tracer,
                 .dir_fd = dir_fd,
                 .fd = fd,
+                .purpose = options.purpose,
             };
         }
 
         pub fn deinit(storage: *Storage) void {
             assert(storage.fd != IO.INVALID_FILE);
             assert(storage.dir_fd != IO.INVALID_FILE);
+            assert(storage.unflushed == 0);
 
             std.posix.close(storage.fd);
             storage.fd = IO.INVALID_FILE;
@@ -382,10 +385,12 @@ pub fn StorageType(comptime IO: type) type {
             assert(write.offset % constants.sector_size == 0);
             self.assert_bounds(write.buffer, write.offset);
 
-            const dsync = write.zone.dsync();
+            const dsync = write.zone.dsync() or self.purpose == .format;
 
             if (!dsync) {
-                assert(write.zone == .grid);
+                if (self.purpose != .format) {
+                    assert(write.zone == .grid);
+                }
                 self.unflushed += 1;
             }
 

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -385,7 +385,7 @@ pub fn StorageType(comptime IO: type) type {
             assert(write.offset % constants.sector_size == 0);
             self.assert_bounds(write.buffer, write.offset);
 
-            const dsync = write.zone.dsync() or self.purpose == .format;
+            const dsync = if (self.purpose == .format) false else write.zone.dsync();
 
             if (!dsync) {
                 if (self.purpose != .format) {

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const maybe = stdx.maybe;
 const log = std.log.scoped(.storage);
@@ -85,6 +86,11 @@ pub fn StorageType(comptime IO: type) type {
             start: ?stdx.Instant,
         };
 
+        pub const Flush = struct {
+            completion: IO.Completion,
+            callback: *const fn (write: *Storage.Flush) void,
+        };
+
         pub const NextTick = IO.Completion;
 
         pub const NextTickSource = IO.NextTickSource;
@@ -93,6 +99,7 @@ pub fn StorageType(comptime IO: type) type {
         tracer: *Tracer,
         dir_fd: IO.fd_t,
         fd: IO.fd_t,
+        unflushed: u64 = 0,
 
         pub fn init(io: *IO, tracer: *Tracer, options: struct {
             path: []const u8,
@@ -375,6 +382,13 @@ pub fn StorageType(comptime IO: type) type {
             assert(write.offset % constants.sector_size == 0);
             self.assert_bounds(write.buffer, write.offset);
 
+            const dsync = write.zone.dsync();
+
+            if (!dsync) {
+                assert(write.zone == .grid);
+                self.unflushed += 1;
+            }
+
             self.io.write(
                 *Storage,
                 self,
@@ -383,6 +397,7 @@ pub fn StorageType(comptime IO: type) type {
                 self.fd,
                 write.buffer,
                 write.offset,
+                .{ .dsync = dsync },
             );
         }
 
@@ -438,6 +453,49 @@ pub fn StorageType(comptime IO: type) type {
             }
 
             self.start_write(write);
+        }
+
+        pub fn flush_sectors(
+            self: *Storage,
+            callback: *const fn (flush: *Storage.Flush) void,
+            flush: *Storage.Flush,
+        ) void {
+            flush.* = .{
+                .completion = undefined,
+                .callback = callback,
+            };
+
+            if (IO.dsync_all) {
+                // Both Windows and Linux have fast DSYNC writes. Only macOS does not.
+                assert(builtin.os.tag == .windows or builtin.os.tag == .linux);
+
+                self.unflushed = 0;
+                return self.fsync_callback(&flush.completion, {});
+            }
+
+            self.io.fsync(
+                *Storage,
+                self,
+                fsync_callback,
+                &flush.completion,
+                self.fd,
+            );
+        }
+
+        fn fsync_callback(
+            self: *Storage,
+            completion: *IO.Completion,
+            result: IO.FsyncError!void,
+        ) void {
+            _ = result catch @panic("fsync failure");
+
+            const flush: *Storage.Flush = @fieldParentPtr(
+                "completion",
+                completion,
+            );
+
+            self.unflushed = 0;
+            flush.callback(flush);
         }
 
         /// Ensures that the read or write is within bounds and intends to read or write some bytes.

--- a/src/testing/io.zig
+++ b/src/testing/io.zig
@@ -214,7 +214,10 @@ pub const IO = struct {
         fd: fd_t,
         buffer: []const u8,
         offset: u64,
+        options: struct { dsync: bool },
     ) void {
+        _ = options;
+
         assert(fd < self.files.len);
 
         self.submit(

--- a/src/testing/storage.zig
+++ b/src/testing/storage.zig
@@ -125,6 +125,10 @@ pub const Storage = struct {
         }
     };
 
+    pub const Flush = struct {
+        callback: *const fn (write: *Storage.Flush) void,
+    };
+
     pub const NextTick = struct {
         link: QueueType(NextTick).Link = .{},
         source: NextTickSource,
@@ -189,6 +193,7 @@ pub const Storage = struct {
 
     reads: std.PriorityQueue(*Storage.Read, void, Storage.Read.less_than),
     writes: std.PriorityQueue(*Storage.Write, void, Storage.Write.less_than),
+    unflushed: u64 = 0,
 
     ticks: u64 = 0,
     next_tick_queue: QueueType(NextTick) = QueueType(NextTick).init(.{
@@ -661,6 +666,16 @@ pub const Storage = struct {
             stdx.copy_disjoint(.inexact, u8, overlay_mistaken_buffer, write.buffer);
             stdx.copy_disjoint(.inexact, u8, overlay_intended_buffer, target_intended_buffer);
         }
+    }
+
+    pub fn flush_sectors(
+        storage: *Storage,
+        callback: *const fn (flush: *Storage.Flush) void,
+        flush: *Storage.Flush,
+    ) void {
+        storage.unflushed = 0;
+        flush.callback = callback;
+        flush.callback(flush);
     }
 
     fn read_latency(storage: *Storage) Duration {

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -967,6 +967,7 @@ const Workload = struct {
             workload.driver.stdin.?.handle,
             workload.request_buffer[workload.request_written.?..workload.request_size.?],
             0,
+            .{ .dsync = true }, // Meaningless when not writing to a real file.
         );
     }
 

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -196,6 +196,22 @@ pub const Zone = enum {
         };
     }
 
+    pub fn dsync(zone: Zone) bool {
+        return switch (zone) {
+            .grid => false,
+            else => true,
+        };
+    }
+
+    // Ensuring only the grid can be written without dsync is _critical_ to safety!
+    comptime {
+        for (std.enums.values(Zone)) |zone| {
+            if (!zone.dsync()) {
+                assert(zone == .grid);
+            }
+        }
+    }
+
     /// Ensures that the read or write is aligned correctly for Direct I/O.
     /// If this is not the case, then the underlying syscall will return EINVAL.
     /// We check this only at the start of a read or write because the physical sector size may be

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -44,6 +44,7 @@ pub fn GridType(comptime Storage: type) type {
 
         // Grid just reuses the Storage's NextTick abstraction for simplicity.
         pub const NextTick = Storage.NextTick;
+        pub const Flush = Storage.Flush;
 
         pub const Write = struct {
             callback: *const fn (*Grid.Write) void,

--- a/src/vsr/replica_format.zig
+++ b/src/vsr/replica_format.zig
@@ -29,6 +29,7 @@ pub fn format(
 
     try replica_format.queue_format_wal(options.cluster, storage);
     replica_format.format_and_tick(storage, &superblock, options);
+    replica_format.flush_and_tick(storage);
     replica_format.verify_writes();
 }
 
@@ -59,6 +60,8 @@ fn ReplicaFormatType(comptime Storage: type) type {
 
         sectors_written: std.DynamicBitSetUnmanaged,
         arena: std.heap.ArenaAllocator,
+
+        flush: Storage.Flush = undefined,
 
         fn init(gpa: std.mem.Allocator) !ReplicaFormat {
             var sectors_written = try std.DynamicBitSetUnmanaged.initEmpty(
@@ -209,6 +212,21 @@ fn ReplicaFormatType(comptime Storage: type) type {
                 superblock_options,
             );
             while (self.formatting_superblock) storage.run();
+        }
+
+        fn flush_and_tick(self: *ReplicaFormat, storage: *Storage) void {
+            assert(!self.formatting and !self.formatting_superblock);
+            assert(self.writes_pending == 0);
+
+            storage.flush_sectors(flush_callback, &self.flush);
+
+            self.formatting = true;
+            while (self.formatting) storage.run();
+        }
+
+        fn flush_callback(flush: *Storage.Flush) void {
+            const self: *ReplicaFormat = @alignCast(@fieldParentPtr("flush", flush));
+            self.formatting = false;
         }
 
         fn write_sectors_callback(storage_write: *Storage.Write) void {


### PR DESCRIPTION
Reworked from #2368, this specifically targets macOS fsync. All other platforms continue to run with DSYNC on.