### PR TITLE
clients/ruby: Allow symbol arrays for flags

### DIFF
--- a/src/clients/ruby/docs/migration.md
+++ b/src/clients/ruby/docs/migration.md
@@ -89,10 +89,11 @@ account_1, account_2 = client.lookup_accounts([100, 101])
 
 ### Flag handling
 
-All flags are now explicit numeric constants combined with `|`, not symbol arrays.
+Flags can be passed as explicit numeric constants combined with `|`, or as
+arrays of lowercase or uppercase symbols.
 
 ```rb
-# Before
+# Before, still valid
 filter = TigerBeetle::AccountFilter.new(
   account_id: 100,
   limit: 10,
@@ -101,7 +102,7 @@ filter = TigerBeetle::AccountFilter.new(
 
 transfers = client.get_account_transfers(filter)
 
-# After
+# After, alternative version
 filter = TigerBeetle::AccountFilter.new(
   account_id: 100,
   limit: 10,
@@ -111,6 +112,9 @@ filter = TigerBeetle::AccountFilter.new(
 
 transfers = client.get_account_transfers(filter)
 ```
+
+The constant form is preferred because editors can autocomplete the available
+flags, but symbol arrays remain supported for compatibility.
 
 ### Timestamp attributes
 

--- a/src/clients/ruby/ruby_bindings.zig
+++ b/src/clients/ruby/ruby_bindings.zig
@@ -121,6 +121,43 @@ fn field_reserved(comptime field_name: []const u8) bool {
     return false;
 }
 
+fn is_flags_type(comptime Type: type) bool {
+    const type_info = @typeInfo(Type);
+    return type_info == .@"struct" and type_info.@"struct".layout == .@"packed";
+}
+
+fn emit_flags_helper_module(buffer: *Buffer) void {
+    buffer.write(
+        \\  module Flags
+        \\    def from(value)
+        \\      case value
+        \\      when Integer
+        \\        value
+        \\      when Array
+        \\        value.reduce(0) { |flags, flag| flags | const_get(flag.upcase) }
+        \\      else
+        \\        raise TypeError, "expected Integer or Array[Symbol] for #{name}"
+        \\      end
+        \\    rescue NameError
+        \\      raise ArgumentError, "unknown flag for #{name}: #{value.inspect}"
+        \\    end
+        \\  end
+        \\
+        \\  module FlagField
+        \\    def self.included(base)
+        \\      flags_module_name = "#{base.name.split("::").last}Flags"
+        \\      flags_module = TigerBeetle.const_get(flags_module_name)
+        \\
+        \\      base.define_method(:flags=) do |value|
+        \\        @flags = flags_module.from(value)
+        \\      end
+        \\    end
+        \\  end
+        \\
+        \\
+    );
+}
+
 fn emit_flags_module(
     buffer: *Buffer,
     comptime Type: type,
@@ -130,6 +167,7 @@ fn emit_flags_module(
     assert(@typeInfo(Type).@"struct".layout == .@"packed");
 
     buffer.print("  module {s}\n", .{ruby_name});
+    buffer.print("    extend Flags\n\n", .{});
     buffer.print("    NONE = 0\n", .{});
     inline for (@typeInfo(Type).@"struct".fields, 0..) |field, i| {
         if (comptime std.mem.startsWith(u8, field.name, "deprecated_")) continue;
@@ -164,9 +202,7 @@ fn emit_enum_module(
 }
 
 fn emit_field_default(buffer: *Buffer, comptime FieldType: type) void {
-    const type_info = @typeInfo(FieldType);
-    const is_flags = type_info == .@"struct" and type_info.@"struct".layout == .@"packed";
-    if (is_flags) {
+    if (comptime is_flags_type(FieldType)) {
         buffer.print("{s}::NONE", .{comptime ruby_flags_name_from_type(FieldType).?});
     } else {
         buffer.print("0", .{});
@@ -183,20 +219,35 @@ fn emit_struct_class(
     assert(@typeInfo(Type).@"struct".layout == .@"extern");
 
     const fields = @typeInfo(Type).@"struct".fields;
+    comptime var flags_type: ?type = null;
+    inline for (fields) |field| {
+        if (comptime is_flags_type(field.type)) {
+            flags_type = field.type;
+        }
+    }
 
     buffer.print("  class {s}\n", .{ruby_name});
+    if (comptime flags_type != null and !read_only) {
+        buffer.print("    include FlagField\n\n", .{});
+    }
 
     inline for (fields) |field| {
         if (comptime std.mem.eql(u8, field.name, "reserved")) continue;
-        buffer.print(
-            "    attr_{s} :{s}\n",
-            .{ if (read_only) "reader" else "accessor", field.name },
-        );
-        if (comptime read_only and
-            std.mem.eql(u8, field.name, "status") and
-            result_status_type(Type) != null)
-        {
-            buffer.print("    attr_reader :status_name\n", .{});
+        const field_is_flags = comptime is_flags_type(field.type);
+        if (field_is_flags) {
+            // Flag field writers are provided by the FlagField module.
+            buffer.print("    attr_reader :{s}\n", .{field.name});
+        } else {
+            buffer.print(
+                "    attr_{s} :{s}\n",
+                .{ if (read_only) "reader" else "accessor", field.name },
+            );
+            if (comptime read_only and
+                std.mem.eql(u8, field.name, "status") and
+                result_status_type(Type) != null)
+            {
+                buffer.print("    attr_reader :status_name\n", .{});
+            }
         }
     }
     buffer.print("\n", .{});
@@ -214,7 +265,11 @@ fn emit_struct_class(
         buffer.print("\n    )\n", .{});
         inline for (fields) |field| {
             if (comptime std.mem.eql(u8, field.name, "reserved")) continue;
-            buffer.print("      @{s} = {s}\n", .{ field.name, field.name });
+            if (comptime is_flags_type(field.type)) {
+                buffer.print("      self.{s} = {s}\n", .{ field.name, field.name });
+            } else {
+                buffer.print("      @{s} = {s}\n", .{ field.name, field.name });
+            }
         }
         buffer.print("    end\n", .{});
     } else {
@@ -246,6 +301,7 @@ fn emit_rbs_constants_module(
     switch (@typeInfo(Type)) {
         .@"struct" => |info| {
             assert(info.layout == .@"packed");
+            buffer.print("    def self.from: (flags) -> Integer\n\n", .{});
             buffer.print("    NONE: Integer\n", .{});
             inline for (info.fields) |field| {
                 if (comptime std.mem.startsWith(u8, field.name, "deprecated_")) continue;
@@ -304,15 +360,20 @@ fn emit_rbs_struct_class(
 
     inline for (fields) |field| {
         if (comptime std.mem.eql(u8, field.name, "reserved")) continue;
-        buffer.print(
-            "    attr_{s} {s}: Integer\n",
-            .{ if (read_only) "reader" else "accessor", field.name },
-        );
-        if (comptime read_only and std.mem.eql(u8, field.name, "status")) {
-            if (comptime Type == tb.CreateAccountResult) {
-                buffer.print("    attr_reader status_name: create_account_status_name\n", .{});
-            } else if (comptime Type == tb.CreateTransferResult) {
-                buffer.print("    attr_reader status_name: create_transfer_status_name\n", .{});
+        if (comptime is_flags_type(field.type)) {
+            buffer.print("    attr_reader {s}: Integer\n", .{field.name});
+            buffer.print("    def {s}=: (flags) -> Integer\n", .{field.name});
+        } else {
+            buffer.print(
+                "    attr_{s} {s}: Integer\n",
+                .{ if (read_only) "reader" else "accessor", field.name },
+            );
+            if (comptime read_only and std.mem.eql(u8, field.name, "status")) {
+                if (comptime Type == tb.CreateAccountResult) {
+                    buffer.print("    attr_reader status_name: create_account_status_name\n", .{});
+                } else if (comptime Type == tb.CreateTransferResult) {
+                    buffer.print("    attr_reader status_name: create_transfer_status_name\n", .{});
+                }
             }
         }
     }
@@ -325,7 +386,8 @@ fn emit_rbs_struct_class(
         comptime var sep: []const u8 = "";
         inline for (fields) |field| {
             if (comptime std.mem.eql(u8, field.name, "reserved")) continue;
-            buffer.print("{s}?{s}: Integer", .{ sep, field.name });
+            const type_name = if (comptime is_flags_type(field.type)) "flags" else "Integer";
+            buffer.print("{s}?{s}: {s}", .{ sep, field.name, type_name });
             sep = ", ";
         }
         buffer.print(") -> void\n", .{});
@@ -345,6 +407,8 @@ fn emit_rbs_bindings(buffer: *Buffer) void {
         \\
         \\module TigerBeetle
         \\  VERSION: String
+        \\
+        \\  type flags = Integer | Array[Symbol]
         \\
         \\  def self.id: () -> Integer
         \\
@@ -425,6 +489,8 @@ fn emit_ruby_bindings(buffer: *Buffer) void {
         \\
     , .{});
 
+    emit_flags_helper_module(buffer);
+
     // Flag modules (packed structs).
     inline for (flag_mappings) |mapping| {
         const ZigType, const ruby_name = mapping;
@@ -451,6 +517,8 @@ fn emit_ruby_bindings(buffer: *Buffer) void {
     emit_struct_class(buffer, tb.CreateAccountResult, "CreateAccountResult", true);
     emit_struct_class(buffer, tb.CreateTransferResult, "CreateTransferResult", true);
 
+    buffer.print("  private_constant :Flags\n", .{});
+    buffer.print("  private_constant :FlagField\n", .{});
     buffer.print("end\n", .{});
 }
 

--- a/src/clients/ruby/sig/tigerbeetle.rbs
+++ b/src/clients/ruby/sig/tigerbeetle.rbs
@@ -6,6 +6,8 @@
 module TigerBeetle
   VERSION: String
 
+  type flags = Integer | Array[Symbol]
+
   def self.id: () -> Integer
 
   class InitError < StandardError
@@ -35,6 +37,8 @@ module TigerBeetle
   end
 
   module AccountFlags
+    def self.from: (flags) -> Integer
+
     NONE: Integer
     LINKED: Integer
     DEBITS_MUST_NOT_EXCEED_CREDITS: Integer
@@ -45,6 +49,8 @@ module TigerBeetle
   end
 
   module TransferFlags
+    def self.from: (flags) -> Integer
+
     NONE: Integer
     LINKED: Integer
     PENDING: Integer
@@ -58,6 +64,8 @@ module TigerBeetle
   end
 
   module AccountFilterFlags
+    def self.from: (flags) -> Integer
+
     NONE: Integer
     DEBITS: Integer
     CREDITS: Integer
@@ -65,6 +73,8 @@ module TigerBeetle
   end
 
   module QueryFilterFlags
+    def self.from: (flags) -> Integer
+
     NONE: Integer
     REVERSED: Integer
   end
@@ -192,10 +202,11 @@ module TigerBeetle
     attr_accessor user_data_32: Integer
     attr_accessor ledger: Integer
     attr_accessor code: Integer
-    attr_accessor flags: Integer
+    attr_reader flags: Integer
+    def flags=: (flags) -> Integer
     attr_accessor timestamp: Integer
 
-    def initialize: (?id: Integer, ?debits_pending: Integer, ?debits_posted: Integer, ?credits_pending: Integer, ?credits_posted: Integer, ?user_data_128: Integer, ?user_data_64: Integer, ?user_data_32: Integer, ?ledger: Integer, ?code: Integer, ?flags: Integer, ?timestamp: Integer) -> void
+    def initialize: (?id: Integer, ?debits_pending: Integer, ?debits_posted: Integer, ?credits_pending: Integer, ?credits_posted: Integer, ?user_data_128: Integer, ?user_data_64: Integer, ?user_data_32: Integer, ?ledger: Integer, ?code: Integer, ?flags: flags, ?timestamp: Integer) -> void
   end
 
   class Transfer
@@ -210,10 +221,11 @@ module TigerBeetle
     attr_accessor timeout: Integer
     attr_accessor ledger: Integer
     attr_accessor code: Integer
-    attr_accessor flags: Integer
+    attr_reader flags: Integer
+    def flags=: (flags) -> Integer
     attr_accessor timestamp: Integer
 
-    def initialize: (?id: Integer, ?debit_account_id: Integer, ?credit_account_id: Integer, ?amount: Integer, ?pending_id: Integer, ?user_data_128: Integer, ?user_data_64: Integer, ?user_data_32: Integer, ?timeout: Integer, ?ledger: Integer, ?code: Integer, ?flags: Integer, ?timestamp: Integer) -> void
+    def initialize: (?id: Integer, ?debit_account_id: Integer, ?credit_account_id: Integer, ?amount: Integer, ?pending_id: Integer, ?user_data_128: Integer, ?user_data_64: Integer, ?user_data_32: Integer, ?timeout: Integer, ?ledger: Integer, ?code: Integer, ?flags: flags, ?timestamp: Integer) -> void
   end
 
   class AccountFilter
@@ -225,9 +237,10 @@ module TigerBeetle
     attr_accessor timestamp_min: Integer
     attr_accessor timestamp_max: Integer
     attr_accessor limit: Integer
-    attr_accessor flags: Integer
+    attr_reader flags: Integer
+    def flags=: (flags) -> Integer
 
-    def initialize: (?account_id: Integer, ?user_data_128: Integer, ?user_data_64: Integer, ?user_data_32: Integer, ?code: Integer, ?timestamp_min: Integer, ?timestamp_max: Integer, ?limit: Integer, ?flags: Integer) -> void
+    def initialize: (?account_id: Integer, ?user_data_128: Integer, ?user_data_64: Integer, ?user_data_32: Integer, ?code: Integer, ?timestamp_min: Integer, ?timestamp_max: Integer, ?limit: Integer, ?flags: flags) -> void
   end
 
   class QueryFilter
@@ -239,9 +252,10 @@ module TigerBeetle
     attr_accessor timestamp_min: Integer
     attr_accessor timestamp_max: Integer
     attr_accessor limit: Integer
-    attr_accessor flags: Integer
+    attr_reader flags: Integer
+    def flags=: (flags) -> Integer
 
-    def initialize: (?user_data_128: Integer, ?user_data_64: Integer, ?user_data_32: Integer, ?ledger: Integer, ?code: Integer, ?timestamp_min: Integer, ?timestamp_max: Integer, ?limit: Integer, ?flags: Integer) -> void
+    def initialize: (?user_data_128: Integer, ?user_data_64: Integer, ?user_data_32: Integer, ?ledger: Integer, ?code: Integer, ?timestamp_min: Integer, ?timestamp_max: Integer, ?limit: Integer, ?flags: flags) -> void
   end
 
   class AccountBalance

--- a/src/clients/ruby/src/tigerbeetle/bindings.rb
+++ b/src/clients/ruby/src/tigerbeetle/bindings.rb
@@ -4,7 +4,35 @@
 ########################################################
 
 module TigerBeetle
+  module Flags
+    def from(value)
+      case value
+      when Integer
+        value
+      when Array
+        value.reduce(0) { |flags, flag| flags | const_get(flag.upcase) }
+      else
+        raise TypeError, "expected Integer or Array[Symbol] for #{name}"
+      end
+    rescue NameError
+      raise ArgumentError, "unknown flag for #{name}: #{value.inspect}"
+    end
+  end
+
+  module FlagField
+    def self.included(base)
+      flags_module_name = "#{base.name.split("::").last}Flags"
+      flags_module = TigerBeetle.const_get(flags_module_name)
+
+      base.define_method(:flags=) do |value|
+        @flags = flags_module.from(value)
+      end
+    end
+  end
+
   module AccountFlags
+    extend Flags
+
     NONE = 0
     LINKED = 1 << 0
     DEBITS_MUST_NOT_EXCEED_CREDITS = 1 << 1
@@ -15,6 +43,8 @@ module TigerBeetle
   end
 
   module TransferFlags
+    extend Flags
+
     NONE = 0
     LINKED = 1 << 0
     PENDING = 1 << 1
@@ -28,6 +58,8 @@ module TigerBeetle
   end
 
   module AccountFilterFlags
+    extend Flags
+
     NONE = 0
     DEBITS = 1 << 0
     CREDITS = 1 << 1
@@ -35,6 +67,8 @@ module TigerBeetle
   end
 
   module QueryFilterFlags
+    extend Flags
+
     NONE = 0
     REVERSED = 1 << 0
   end
@@ -152,6 +186,8 @@ module TigerBeetle
   end
 
   class Account
+    include FlagField
+
     attr_accessor :id
     attr_accessor :debits_pending
     attr_accessor :debits_posted
@@ -162,7 +198,7 @@ module TigerBeetle
     attr_accessor :user_data_32
     attr_accessor :ledger
     attr_accessor :code
-    attr_accessor :flags
+    attr_reader :flags
     attr_accessor :timestamp
 
     def initialize(
@@ -189,12 +225,14 @@ module TigerBeetle
       @user_data_32 = user_data_32
       @ledger = ledger
       @code = code
-      @flags = flags
+      self.flags = flags
       @timestamp = timestamp
     end
   end
 
   class Transfer
+    include FlagField
+
     attr_accessor :id
     attr_accessor :debit_account_id
     attr_accessor :credit_account_id
@@ -206,7 +244,7 @@ module TigerBeetle
     attr_accessor :timeout
     attr_accessor :ledger
     attr_accessor :code
-    attr_accessor :flags
+    attr_reader :flags
     attr_accessor :timestamp
 
     def initialize(
@@ -235,12 +273,14 @@ module TigerBeetle
       @timeout = timeout
       @ledger = ledger
       @code = code
-      @flags = flags
+      self.flags = flags
       @timestamp = timestamp
     end
   end
 
   class AccountFilter
+    include FlagField
+
     attr_accessor :account_id
     attr_accessor :user_data_128
     attr_accessor :user_data_64
@@ -249,7 +289,7 @@ module TigerBeetle
     attr_accessor :timestamp_min
     attr_accessor :timestamp_max
     attr_accessor :limit
-    attr_accessor :flags
+    attr_reader :flags
 
     def initialize(
       account_id: 0,
@@ -270,11 +310,13 @@ module TigerBeetle
       @timestamp_min = timestamp_min
       @timestamp_max = timestamp_max
       @limit = limit
-      @flags = flags
+      self.flags = flags
     end
   end
 
   class QueryFilter
+    include FlagField
+
     attr_accessor :user_data_128
     attr_accessor :user_data_64
     attr_accessor :user_data_32
@@ -283,7 +325,7 @@ module TigerBeetle
     attr_accessor :timestamp_min
     attr_accessor :timestamp_max
     attr_accessor :limit
-    attr_accessor :flags
+    attr_reader :flags
 
     def initialize(
       user_data_128: 0,
@@ -304,7 +346,7 @@ module TigerBeetle
       @timestamp_min = timestamp_min
       @timestamp_max = timestamp_max
       @limit = limit
-      @flags = flags
+      self.flags = flags
     end
   end
 
@@ -352,4 +394,6 @@ module TigerBeetle
       "#<#{self.class} timestamp=#{@timestamp} status_name=#{@status_name}>"
   end
 
+  private_constant :Flags
+  private_constant :FlagField
 end

--- a/src/clients/ruby/tests/unit/test_flags.rb
+++ b/src/clients/ruby/tests/unit/test_flags.rb
@@ -1,0 +1,72 @@
+require "minitest/autorun"
+require "tigerbeetle"
+
+class TestFlags < Minitest::Test
+  def test_account_flags_accept_integer
+    account = TigerBeetle::Account.new(
+      id: 1,
+      ledger: 1,
+      code: 1,
+      flags: TigerBeetle::AccountFlags::LINKED | TigerBeetle::AccountFlags::HISTORY
+    )
+
+    assert_equal(
+      TigerBeetle::AccountFlags::LINKED | TigerBeetle::AccountFlags::HISTORY,
+      account.flags
+    )
+  end
+
+  def test_account_flags_accept_lowercase_symbols
+    account = TigerBeetle::Account.new(id: 1, ledger: 1, code: 1, flags: [:linked, :history])
+
+    assert_equal(
+      TigerBeetle::AccountFlags::LINKED | TigerBeetle::AccountFlags::HISTORY,
+      account.flags
+    )
+  end
+
+  def test_transfer_flags_accept_uppercase_symbols
+    transfer = TigerBeetle::Transfer.new(id: 1, flags: [:LINKED, :PENDING])
+
+    assert_equal(
+      TigerBeetle::TransferFlags::LINKED | TigerBeetle::TransferFlags::PENDING,
+      transfer.flags
+    )
+  end
+
+  def test_flag_writer_coerces
+    account = TigerBeetle::Account.new(id: 1, ledger: 1, code: 1)
+
+    account.flags = [:imported, :linked]
+
+    assert_equal(
+      TigerBeetle::AccountFlags::IMPORTED | TigerBeetle::AccountFlags::LINKED,
+      account.flags
+    )
+  end
+
+  def test_empty_flag_array_is_none
+    filter = TigerBeetle::AccountFilter.new(account_id: 1, limit: 1, flags: [])
+
+    assert_equal(TigerBeetle::AccountFilterFlags::NONE, filter.flags)
+  end
+
+  def test_unknown_flag_raises_argument_error_with_dynamic_module_name
+    error = assert_raises(ArgumentError) do
+      TigerBeetle::QueryFilter.new(limit: 1, flags: [:unknown])
+    end
+
+    assert_equal("unknown flag for TigerBeetle::QueryFilterFlags: [:unknown]", error.message)
+  end
+
+  def test_invalid_flag_type_raises_type_error_with_dynamic_module_name
+    error = assert_raises(TypeError) do
+      TigerBeetle::Account.new(id: 1, ledger: 1, code: 1, flags: "linked")
+    end
+
+    assert_equal(
+      "expected Integer or Array[Symbol] for TigerBeetle::AccountFlags",
+      error.message
+    )
+  end
+end


### PR DESCRIPTION
@matklad We had originally discussed this [here](https://github.com/tigerbeetle/tigerbeetle/pull/3787#discussion_r3386328944). I have no strong opinion either way, but I've had this branch sit around for ~2 months now and think we should just make a call either way and move on. 

Due to Ruby not having real numeric enums, a lot of code defaults to using symbol arrays in situations like this. As pointed out in the updated migration guide, the named constants are actually nicer because editors can autocomplete them, but the symbol arrays are what most Ruby developers would expect.

It's your call really: it makes the code more complex (bad), for a solution that feels more idiomatic (good), but on aggregate is probably slightly inferior (tooling-wise) and deviates from other clients. 🤷‍♂️