### PR TITLE
fix(client): handle all IO.init errors instead of aborting on unreachable

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -320,9 +320,14 @@ pub fn ContextType(
                     @errorName(err),
                 });
                 return switch (err) {
-                    error.ProcessFdQuotaExceeded => error.SystemResources,
+                    error.ProcessFdQuotaExceeded,
+                    error.SystemFdQuotaExceeded,
+                    error.SystemResources,
+                    => error.SystemResources,
+                    error.PermissionDenied,
+                    error.SystemOutdated,
+                    => error.NetworkSubsystemFailed,
                     error.Unexpected => error.Unexpected,
-                    else => unreachable,
                 };
             };
             errdefer context.io.deinit();


### PR DESCRIPTION
### Problem

When `IO.init` (io_uring setup) fails with `error.SystemResources` — e.g. because the per-user `RLIMIT_MEMLOCK` budget is exhausted — the Zig-side client init aborts the entire embedding process with SIGABRT instead of returning an error status. Every language client documents and implements handling for `TB_INIT_SYSTEM_RESOURCES`, but that arm is unreachable because the process is already dead.

Minimal reproduction (Linux):
```
$ bash -c 'ulimit -l 0; ./probe'
error(tb_client_context): ...: failed to initialize IO: SystemResources
thread 2877243 panic: attempt to unwrap error: SystemResources
SIGABRT: abort
```

The same abort occurs for `error.PermissionDenied` (io_uring disabled by seccomp/sysctl), `error.SystemOutdated` (kernel lacks io_uring), and `error.SystemFdQuotaExceeded` (system-wide fd limit).

### Root Cause

In `src/clients/c/tb_client/context.zig`, the `IO.init` error handler only matches two variants and sends everything else to `unreachable`:

```zig
return switch (err) {
    error.ProcessFdQuotaExceeded => error.SystemResources,
    error.Unexpected => error.Unexpected,
    else => unreachable,  // aborts on SystemResources, PermissionDenied, etc.
};
```

`IO.init` delegates to `std.os.linux.IoUring.init()` which can return `SystemResources`, `PermissionDenied`, `SystemOutdated`, and `SystemFdQuotaExceeded` in addition to the two handled variants. All four hit `unreachable`.

### Solution

Make the switch exhaustive by handling the missing error variants:

- `SystemResources`, `SystemFdQuotaExceeded` → `error.SystemResources` (resource exhaustion, maps to `TB_INIT_SYSTEM_RESOURCES`)
- `PermissionDenied`, `SystemOutdated` → `error.NetworkSubsystemFailed` (IO subsystem structurally unavailable, maps to `TB_INIT_NETWORK_SUBSYSTEM`)

Removing the `else` branch makes the switch exhaustive: if a future Zig version adds a new error variant to `IoUring.init()`, the code will fail at compile time rather than silently aborting at runtime.

### Test Plan

- **Compile-time safety**: the exhaustive switch (no `else`) guarantees that new `IO.init` error variants produce a build error instead of a runtime abort.
- The original issue's reproducer (`ulimit -l 0; ./probe`) should now return `ErrSystemResources` to the Go caller instead of SIGABRT. Requires a Linux environment.

Fixes #3913
